### PR TITLE
Fixed JSONDecodeError with invalid oauth/camunda credentials

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -37,3 +37,7 @@ All ``pyzeebe`` exceptions inherit from :py:class:`PyZeebeException`
 .. autoexception:: pyzeebe.exceptions.ZeebeGatewayUnavailable
 
 .. autoexception:: pyzeebe.exceptions.ZeebeInternalError
+
+.. autoexception:: pyzeebe.exceptions.InvalidOAuthCredentials
+
+.. autoexception:: pyzeebe.exceptions.InvalidCamundaCloudCredentials

--- a/pyzeebe/credentials/camunda_cloud_credentials.py
+++ b/pyzeebe/credentials/camunda_cloud_credentials.py
@@ -1,10 +1,14 @@
 from pyzeebe.credentials.oauth_credentials import OAuthCredentials
+from pyzeebe.exceptions import InvalidOAuthCredentials, InvalidCamundaCloudCredentials
 
 
 class CamundaCloudCredentials(OAuthCredentials):
     def __init__(self, client_id: str, client_secret: str, cluster_id: str):
-        super().__init__(url="https://login.cloud.camunda.io/oauth/token", client_id=client_id,
-                         client_secret=client_secret, audience=f"{cluster_id}.zeebe.camunda.io")
+        try:
+            super().__init__(url="https://login.cloud.camunda.io/oauth/token", client_id=client_id,
+                             client_secret=client_secret, audience=f"{cluster_id}.zeebe.camunda.io")
+        except InvalidOAuthCredentials:
+            raise InvalidCamundaCloudCredentials(client_id=client_id, cluster_id=cluster_id)
 
     def get_connection_uri(self) -> str:
         return f"{self.audience}:443"

--- a/pyzeebe/exceptions/__init__.py
+++ b/pyzeebe/exceptions/__init__.py
@@ -1,3 +1,4 @@
+from .credentials_exceptions import *
 from .job_exceptions import *
 from .message_exceptions import *
 from .pyzeebe_exceptions import *

--- a/pyzeebe/exceptions/credentials_exceptions.py
+++ b/pyzeebe/exceptions/credentials_exceptions.py
@@ -1,0 +1,12 @@
+from pyzeebe.exceptions.pyzeebe_exceptions import PyZeebeException
+
+
+class InvalidOAuthCredentials(PyZeebeException):
+    def __init__(self, url: str, client_id: str, audience: str):
+        super().__init__(
+            f"Invalid OAuth credentials supplied for {url} with audience {audience} and client id {client_id}")
+
+
+class InvalidCamundaCloudCredentials(PyZeebeException):
+    def __init__(self, client_id: str, cluster_id: str):
+        super().__init__(f"Invalid credentials supplied for cluster {cluster_id} with client {client_id}")

--- a/tests/unit/credentials/camunda_cloud_credentials_test.py
+++ b/tests/unit/credentials/camunda_cloud_credentials_test.py
@@ -1,7 +1,10 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
+import pytest
+
 from pyzeebe.credentials.camunda_cloud_credentials import CamundaCloudCredentials
+from pyzeebe.exceptions import InvalidOAuthCredentials, InvalidCamundaCloudCredentials
 
 
 def test_init():
@@ -13,3 +16,11 @@ def test_init():
         CamundaCloudCredentials(client_id, client_secret, cluster_id)
         init.assert_called_with(url=f"https://login.cloud.camunda.io/oauth/token", client_id=client_id,
                                 client_secret=client_secret, audience=f"{cluster_id}.zeebe.camunda.io")
+
+
+def test_invalid_credentials():
+    CamundaCloudCredentials.get_access_token = MagicMock(
+        side_effect=InvalidOAuthCredentials(str(uuid4()), str(uuid4()), str(uuid4())))
+
+    with pytest.raises(InvalidCamundaCloudCredentials):
+        CamundaCloudCredentials(str(uuid4()), str(uuid4()), str(uuid4()))

--- a/tests/unit/credentials/oauth_credentials_test.py
+++ b/tests/unit/credentials/oauth_credentials_test.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
+from requests import HTTPError
+
 from pyzeebe.credentials.oauth_credentials import OAuthCredentials
+from pyzeebe.exceptions import InvalidOAuthCredentials
 
 
 def test_get_access_token():
@@ -17,3 +21,12 @@ def test_get_access_token():
                                          "client_secret": client_secret,
                                          "audience": audience
                                      })
+
+
+def test_get_invalid_access_token():
+    with patch("requests_oauthlib.OAuth2Session.post") as post_mock:
+        post_mock.side_effect = HTTPError()
+
+        with pytest.raises(InvalidOAuthCredentials):
+            OAuthCredentials.get_access_token(url=f"https://{str(uuid4())}/oauth/token", client_id=str(uuid4()),
+                                              client_secret=str(uuid4()), audience=str(uuid4()))

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -1,5 +1,5 @@
 from random import randint
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
 from pyzeebe.credentials.camunda_cloud_credentials import CamundaCloudCredentials
@@ -75,8 +75,10 @@ def test_with_secure_connection():
 
 
 def test_with_camunda_cloud_credentials():
-    with patch("requests_oauthlib.OAuth2Session.post"):
-        credentials = CamundaCloudCredentials(str(uuid4()), str(uuid4()), str(uuid4()))
+    CamundaCloudCredentials.get_access_token = MagicMock()
+    CamundaCloudCredentials.get_access_token.return_value = str(uuid4())
+    credentials = CamundaCloudCredentials(str(uuid4()), str(uuid4()), str(uuid4()))
+
     with patch("grpc.secure_channel") as grpc_secure_channel_mock:
         ZeebeAdapterBase(credentials=credentials)
         grpc_secure_channel_mock.assert_called()
@@ -86,8 +88,9 @@ def test_credentials_connection_uri_gotten():
     client_id = str(uuid4())
     client_secret = str(uuid4())
     cluster_id = str(uuid4())
-    with patch("requests_oauthlib.OAuth2Session.post"):
-        credentials = CamundaCloudCredentials(client_id, client_secret, cluster_id)
+    CamundaCloudCredentials.get_access_token = MagicMock()
+    CamundaCloudCredentials.get_access_token.return_value = str(uuid4())
+    credentials = CamundaCloudCredentials(client_id, client_secret, cluster_id)
     zeebe_adapter = ZeebeAdapterBase(credentials=credentials)
     assert zeebe_adapter.connection_uri == f"{cluster_id}.zeebe.camunda.io:443"
 


### PR DESCRIPTION
Description of PR...

## Changes

- Fixed #42 - Now raising `InvalidOAuthCredentials` and `InvalidCamundaCloudCredentials` respectively


## Checklist

- [x] Unit tests
- [x] Documentation
