### PR TITLE
[ADDED] Ability to add multiple routers at once

### DIFF
--- a/docs/worker_taskrouter.rst
+++ b/docs/worker_taskrouter.rst
@@ -41,6 +41,13 @@ To add the router tasks to the worker we use the :py:func:`include_router` metho
 
     worker.include_router(router)
 
-    ...
+
+Or to add multiple routers at once:
+
+.. code-block:: python
+
+    worker.include_router(router1, router2, router3, ...)
+
+
 
 That's it!

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -245,6 +245,21 @@ def test_include_router():
     assert zeebe_worker.get_task(task_type) is not None
 
 
+def test_include_multiple_routers():
+    routers = [ZeebeTaskRouter() for _ in range(0, randint(2, 100))]
+
+    for router in routers:
+        task_type = str(uuid4())
+
+        @router.task(task_type=task_type)
+        def task_fn(x):
+            return {"x": x}
+
+        zeebe_worker.include_router(router)
+
+    assert len(zeebe_worker.tasks) == len(routers)
+
+
 def test_router_before_decorator():
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         task_type = str(uuid4())


### PR DESCRIPTION
## Changes

- You can now add multiple routers in one call to `include_router`

## API Updates

- Added the option to: `worker.include_router(router1, router2, router3...)`

## Checklist

- [x] Unit tests
- [x] Documentation
