### PR TITLE
Close channel on grpc TRANSIENT_FAILURE

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -20,6 +20,19 @@ To create a client with custom hostname and port:
 
     client = ZeebeClient(hostname="zeebe_gateway", port=26500)
 
+
+To change connection retries:
+
+.. code-block:: python
+
+    worker = ZeebeClient(max_connection_retries=1)  # Will only accept one failure
+
+.. note::
+
+    The default behavior is 10 retries. If you want infinite retries just set to -1.
+
+
+
 To create a client with a secure connection:
 
 .. code-block:: python

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -25,7 +25,10 @@ To change connection retries:
 
 .. code-block:: python
 
-    worker = ZeebeClient(max_connection_retries=1)  # Will only accept one failure
+    worker = ZeebeClient(max_connection_retries=1)  # Will only accept one failure and disconnect upon the second
+
+
+This means the client will disconnect upon two consecutive failures. Each time the client connects successfully the counter is reset.
 
 .. note::
 

--- a/docs/worker_quickstart.rst
+++ b/docs/worker_quickstart.rst
@@ -42,7 +42,9 @@ To change connection retries:
 
 .. code-block:: python
 
-    worker = ZeebeWorker(max_connection_retries=1)  # Will only accept one failure
+    worker = ZeebeWorker(max_connection_retries=1)  # Will only accept one failure and disconnect upon the second
+
+This means the worker will disconnect upon two consecutive failures. Each time the worker connects successfully the counter is reset.
 
 .. note::
 

--- a/docs/worker_quickstart.rst
+++ b/docs/worker_quickstart.rst
@@ -38,6 +38,16 @@ To create a worker with custom hostname and port:
 
     worker = ZeebeWorker(hostname="zeebe_gateway", port=26500)
 
+To change connection retries:
+
+.. code-block:: python
+
+    worker = ZeebeWorker(max_connection_retries=1)  # Will only accept one failure
+
+.. note::
+
+    The default behavior is 10 retries. If you want infinite retries just set to -1.
+
 To create a worker with a secure connection:
 
 .. code-block:: python

--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -7,6 +7,8 @@ from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 
 
 class ZeebeClient(object):
+    """A zeebe client that can connect to a zeebe instance and perform actions."""
+
     def __init__(self, hostname: str = None, port: int = None, credentials: BaseCredentials = None,
                  channel: grpc.Channel = None, secure_connection: bool = False, max_connection_retries: int = 10):
         """

--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -8,9 +8,18 @@ from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 
 class ZeebeClient(object):
     def __init__(self, hostname: str = None, port: int = None, credentials: BaseCredentials = None,
-                 channel: grpc.Channel = None, secure_connection: bool = False):
+                 channel: grpc.Channel = None, secure_connection: bool = False, max_connection_retries: int = 10):
+        """
+        Args:
+            hostname (str): Zeebe instance hostname
+            port (int): Port of the zeebe
+            max_connection_retries (int): Amount of connection retries before client gives up on connecting to zeebe.
+                                            To setup with infinite retries use -1
+        """
+
         self.zeebe_adapter = ZeebeAdapter(hostname=hostname, port=port, credentials=credentials, channel=channel,
-                                          secure_connection=secure_connection)
+                                          secure_connection=secure_connection,
+                                          max_connection_retries=max_connection_retries)
 
     def run_workflow(self, bpmn_process_id: str, variables: Dict = None, version: int = -1) -> int:
         """

--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -13,8 +13,7 @@ class ZeebeClient(object):
         Args:
             hostname (str): Zeebe instance hostname
             port (int): Port of the zeebe
-            max_connection_retries (int): Amount of connection retries before client gives up on connecting to zeebe.
-                                            To setup with infinite retries use -1
+            max_connection_retries (int): Amount of connection retries before client gives up on connecting to zeebe. To setup with infinite retries use -1
         """
 
         self.zeebe_adapter = ZeebeAdapter(hostname=hostname, port=port, credentials=credentials, channel=channel,

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -88,6 +88,7 @@ class ZeebeAdapterBase(object):
                 self._close()
             raise ZeebeGatewayUnavailable()
         elif self.is_error_status(rpc_error, grpc.StatusCode.INTERNAL):
+            self._current_connection_retries += 1
             if not self._should_retry():
                 self._close()
             raise ZeebeInternalError()

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -54,6 +54,7 @@ class ZeebeAdapterBase(object):
             logger.debug(f"Connected to {self.connection_uri or 'zeebe'}")
             self.connected = True
             self.retrying_connection = False
+            self._current_connection_retries = 0
 
         elif value == grpc.ChannelConnectivity.CONNECTING:
             logger.debug(f"Connecting to {self.connection_uri or 'zeebe'}.")

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -89,7 +89,7 @@ class ZeebeAdapterBase(object):
             raise ZeebeGatewayUnavailable()
         elif self.is_error_status(rpc_error, grpc.StatusCode.INTERNAL):
             if not self._should_retry():
-                self._cleanup()
+                self._close()
             raise ZeebeInternalError()
         else:
             raise rpc_error

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -68,7 +68,7 @@ class ZeebeAdapterBase(object):
                 self._current_connection_retries = self._current_connection_retries + 1
             else:
                 logger.error(f"Failed to establish connection to {self.connection_uri or 'zeebe'}. Not recoverable")
-                self._channel.close()
+                self._close()
                 self.retrying_connection = False
                 raise ConnectionAbortedError(f"Lost connection to {self.connection_uri or 'zeebe'}")
 

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class ZeebeAdapterBase(object):
     def __init__(self, hostname: str = None, port: int = None, credentials: BaseCredentials = None,
-                 channel: grpc.Channel = None, secure_connection: bool = False, max_retries: int = 10):
+                 channel: grpc.Channel = None, secure_connection: bool = False, max_connection_retries: int = -1):
         if channel:
             self.connection_uri = None
             self._channel = channel
@@ -25,8 +25,8 @@ class ZeebeAdapterBase(object):
         self.retrying_connection = True
         self._channel.subscribe(self._check_connectivity, try_to_connect=True)
         self._gateway_stub = GatewayStub(self._channel)
-        self._max_retries = max_retries
-        self._current_retries = 0
+        self._max_connection_retries = max_connection_retries
+        self._current_connection_retries = 0
 
     @staticmethod
     def _get_connection_uri(hostname: str = None, port: int = None, credentials: BaseCredentials = None) -> str:
@@ -78,7 +78,7 @@ class ZeebeAdapterBase(object):
             self.retrying_connection = False
 
     def _should_retry(self):
-        return self._max_retries == -1 or self._current_retries < self._max_retries
+        return self._max_connection_retries == -1 or self._current_connection_retries < self._max_connection_retries
 
     def _common_zeebe_grpc_errors(self, rpc_error: grpc.RpcError):
         if self.is_error_status(rpc_error, grpc.StatusCode.RESOURCE_EXHAUSTED):

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -66,6 +66,7 @@ class ZeebeAdapterBase(object):
                 logger.warning(f"Lost connection to {self.connection_uri or 'zeebe'}. Retrying...")
                 self.connected = False
                 self.retrying_connection = True
+                self._current_connection_retries = self._current_connection_retries + 1
             else:
                 logger.error(f"Failed to establish connection to {self.connection_uri or 'zeebe'}. Not recoverable")
                 self._channel.close()

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -61,6 +61,7 @@ class ZeebeAdapterBase(object):
             logging.error(f"Failed to establish connection to {self.connection_uri or 'zeebe'}. Non recoverable")
             self.connected = False
             self.retrying_connection = False
+            self._channel.close()
             raise ConnectionAbortedError(f"Lost connection to {self.connection_uri or 'zeebe'}")
 
     def _common_zeebe_grpc_errors(self, rpc_error: grpc.RpcError):

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -10,8 +10,8 @@ from pyzeebe.exceptions import ActivateJobsRequestInvalid, JobAlreadyDeactivated
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 from pyzeebe.job.job import Job
 
-
 logger = logging.getLogger(__name__)
+
 
 class ZeebeJobAdapter(ZeebeAdapterBase):
     def activate_jobs(self, task_type: str, worker: str, timeout: int, max_jobs_to_activate: int,

--- a/pyzeebe/worker/task_handler.py
+++ b/pyzeebe/worker/task_handler.py
@@ -9,8 +9,8 @@ from pyzeebe.task.exception_handler import ExceptionHandler
 from pyzeebe.task.task import Task
 from pyzeebe.task.task_decorator import TaskDecorator
 
-
 logger = logging.getLogger(__name__)
+
 
 def default_exception_handler(e: Exception, job: Job) -> None:
     logger.warning(f"Task type: {job.type} - failed job {job}. Error: {e}.")

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -20,7 +20,8 @@ class ZeebeWorker(ZeebeTaskHandler):
 
     def __init__(self, name: str = None, request_timeout: int = 0, hostname: str = None, port: int = None,
                  credentials: BaseCredentials = None, secure_connection: bool = False,
-                 before: List[TaskDecorator] = None, after: List[TaskDecorator] = None):
+                 before: List[TaskDecorator] = None, after: List[TaskDecorator] = None,
+                 max_connection_retries: int = 10):
         """
         Args:
             hostname (str): Zeebe instance hostname
@@ -29,10 +30,12 @@ class ZeebeWorker(ZeebeTaskHandler):
             request_timeout (int): Longpolling timeout for getting tasks from zeebe. If 0 default value is used
             before (List[TaskDecorator]): Decorators to be performed before each task
             after (List[TaskDecorator]): Decorators to be performed after each task
+            max_connection_retries (int): Amount of connection retries before worker gives up on connecting to zeebe. To setup with infinite retries use -1
         """
         super().__init__(before, after)
         self.zeebe_adapter = ZeebeAdapter(hostname=hostname, port=port, credentials=credentials,
-                                          secure_connection=secure_connection)
+                                          secure_connection=secure_connection,
+                                          max_connection_retries=max_connection_retries)
         self.name = name or socket.gethostname()
         self.request_timeout = request_timeout
         self.stop_event = Event()

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -12,16 +12,15 @@ from pyzeebe.task.task_decorator import TaskDecorator
 from pyzeebe.worker.task_handler import ZeebeTaskHandler, default_exception_handler
 from pyzeebe.worker.task_router import ZeebeTaskRouter
 
-
 logger = logging.getLogger(__name__)
+
 
 class ZeebeWorker(ZeebeTaskHandler):
     """A zeebe worker that can connect to a zeebe instance and perform tasks."""
 
     def __init__(self, name: str = None, request_timeout: int = 0, hostname: str = None, port: int = None,
                  credentials: BaseCredentials = None, secure_connection: bool = False,
-                 before: List[TaskDecorator] = None,
-                 after: List[TaskDecorator] = None):
+                 before: List[TaskDecorator] = None, after: List[TaskDecorator] = None):
         """
         Args:
             hostname (str): Zeebe instance hostname

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -39,14 +39,14 @@ def test_connectivity_connecting():
 
 
 def test_connectivity_transient_failure_retry():
-    zeebe_adapter._max_retries = 1
+    zeebe_adapter._max_connection_retries = 1
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
     assert zeebe_adapter.retrying_connection
     assert not zeebe_adapter.connected
 
 
 def test_connectivity_transient_failure_no_retry():
-    zeebe_adapter._max_retries = 0
+    zeebe_adapter._max_connection_retries = 0
     zeebe_adapter._channel.close = MagicMock()
     with pytest.raises(ConnectionAbortedError):
         zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
@@ -72,13 +72,13 @@ def test_connectivity_shutdown():
 
 
 def test_should_retry_no_current_retries():
-    zeebe_adapter._max_retries = 1
+    zeebe_adapter._max_connection_retries = 1
     assert zeebe_adapter._should_retry()
 
 
 def test_should_retry_current_retries_over_max():
-    zeebe_adapter._max_retries = 1
-    zeebe_adapter._current_retries = 1
+    zeebe_adapter._max_connection_retries = 1
+    zeebe_adapter._current_connection_retries = 1
     assert not zeebe_adapter._should_retry()
 
 

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -45,8 +45,10 @@ def test_connectivity_transient_failure():
 
 
 def test_connectivity_shutdown():
+    zeebe_adapter._channel.close = MagicMock()
     with pytest.raises(ConnectionAbortedError):
         zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.SHUTDOWN)
+        zeebe_adapter._channel.close.assert_called_once()
 
 
 def test_only_port():

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -172,10 +172,10 @@ def test_common_zeebe_grpc_error_unkown_error():
 def test_cleanup_after_retried():
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
-    zeebe_adapter._cleanup = MagicMock()
+    zeebe_adapter._close = MagicMock()
     zeebe_adapter._max_connection_retries = 1
     with pytest.raises(ZeebeGatewayUnavailable):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
-    zeebe_adapter._cleanup.assert_called_once()
+    zeebe_adapter._close.assert_called_once()
 

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -169,12 +169,24 @@ def test_common_zeebe_grpc_error_unkown_error():
     with pytest.raises(grpc.RpcError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
-def test_close_after_retried():
+
+def test_close_after_retried_unavailable():
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
     zeebe_adapter._close = MagicMock()
     zeebe_adapter._max_connection_retries = 1
     with pytest.raises(ZeebeGatewayUnavailable):
+        zeebe_adapter._common_zeebe_grpc_errors(error)
+
+    zeebe_adapter._close.assert_called_once()
+
+
+def test_close_after_retried_internal():
+    error = grpc.RpcError()
+    error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
+    zeebe_adapter._close = MagicMock()
+    zeebe_adapter._max_connection_retries = 1
+    with pytest.raises(ZeebeInternalError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
     zeebe_adapter._close.assert_called_once()

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -169,7 +169,7 @@ def test_common_zeebe_grpc_error_unkown_error():
     with pytest.raises(grpc.RpcError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
-def test_cleanup_after_retried():
+def test_close_after_retried():
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
     zeebe_adapter._close = MagicMock()
@@ -178,4 +178,3 @@ def test_cleanup_after_retried():
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
     zeebe_adapter._close.assert_called_once()
-

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -168,3 +168,14 @@ def test_common_zeebe_grpc_error_unkown_error():
     error._state = GRPCStatusCode("Nothing")
     with pytest.raises(grpc.RpcError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
+
+def test_cleanup_after_retried():
+    error = grpc.RpcError()
+    error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
+    zeebe_adapter._cleanup = MagicMock()
+    zeebe_adapter._max_connection_retries = 1
+    with pytest.raises(ZeebeGatewayUnavailable):
+        zeebe_adapter._common_zeebe_grpc_errors(error)
+
+    zeebe_adapter._cleanup.assert_called_once()
+


### PR DESCRIPTION
Close grpc channel to Zeebe on TRANSIENT_FAILURE status.

## Changes

- Close the grpc channel on TRANSIENT_FAILURE connectivity

## API Updates

### New Features *(required)*
None.

### Deprecations *(required)*
None.

### Enhancements *(optional)*

- Pyzeebe will close the grpc channel if it receives a `grpc.ChannelConnectivity.TRANSIENT_FAILURE` signal. This fixes an issue where pyzeebe would try to reconnect over and over.

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #74 