### PR TITLE
Add option to wait for task threads to join in worker when stopping

### DIFF
--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -28,8 +28,7 @@ def task_handler(should_throw: bool, input: str) -> Dict:
 def setup():
     global zeebe_client, task_handler
 
-    t = Thread(target=zeebe_worker.work)
-    t.start()
+    zeebe_worker.work()
 
     zeebe_client = ZeebeClient()
     try:
@@ -39,8 +38,8 @@ def setup():
         zeebe_client.deploy_workflow("test.bpmn")
 
     yield zeebe_client
-    zeebe_worker.stop()
-    t.join()
+    zeebe_worker.stop(wait=True)
+    assert not zeebe_worker._task_threads
 
 
 def test_run_workflow():


### PR DESCRIPTION
I am seeing the need to wait for threads to complete when stopping a worker. The difference is visible in the test I changed. Before, the threads would continue to run for a cycle before closing, but the test would move on.  

The overall test suite run time will as a result be perceived as slower, as the threads will be closed before it continues to the next set of tests. The advantage here is that we're sure all threads are finished and won't affect any other tests. 

Before:

```
time pytest -q --durations=0 tests/integration/integration_test.py
....                                                                                                                                                                                                                                                                                                [100%]
====================================== slowest durations ======================================
0.63s call     tests/integration/integration_test.py::test_run_workflow_with_result
0.10s call     tests/integration/integration_test.py::test_cancel_workflow
0.07s call     tests/integration/integration_test.py::test_non_existent_workflow
0.06s setup    tests/integration/integration_test.py::test_run_workflow
0.04s call     tests/integration/integration_test.py::test_run_workflow

(7 durations < 0.005s hidden.  Use -vv to show these durations.)
4 passed in 1.22s
pytest -q --durations=0 tests/integration/integration_test.py  0.61s user 0.16s system 6% cpu 11.601 total
``` 

After:

```
time pytest -q --durations=0 tests/integration/integration_test.py
....                                                                                                                                                                                                                                                                                                [100%]
====================================== slowest durations ======================================
9.70s teardown tests/integration/integration_test.py::test_cancel_workflow
0.82s call     tests/integration/integration_test.py::test_run_workflow_with_result
0.37s setup    tests/integration/integration_test.py::test_run_workflow
0.19s call     tests/integration/integration_test.py::test_run_workflow
0.18s call     tests/integration/integration_test.py::test_non_existent_workflow
0.12s call     tests/integration/integration_test.py::test_cancel_workflow

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
4 passed in 12.31s
pytest -q --durations=0 tests/integration/integration_test.py  0.86s user 0.24s system 8% cpu 13.623 total
```


## Changes

- Add option to wait for task threads to join in worker when stopping
- Update test to use wait method

## API Updates

### New Features *(required)*

Optional parameter to `ZeebeWorker.stop()`.

### Deprecations *(required)*

None

### Enhancements *(optional)*

None

## Checklist

- [x] Unit tests
- [x] Documentation

## References

None