### PR TITLE
Give threads names upon creation, making its responsibility visible

### DIFF
--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -50,7 +50,9 @@ class ZeebeWorker(ZeebeTaskHandler):
 
         """
         for task in self.tasks:
-            task_thread = Thread(target=self._handle_task, args=(task,))
+            task_thread = Thread(target=self._handle_task,
+                                 args=(task,),
+                                 name=f"{self.__class__.__name__}-Task-{task.type}")
             task_thread.start()
 
     def stop(self) -> None:
@@ -70,7 +72,9 @@ class ZeebeWorker(ZeebeTaskHandler):
 
     def _handle_jobs(self, task: Task) -> None:
         for job in self._get_jobs(task):
-            thread = Thread(target=task.handler, args=(job,))
+            thread = Thread(target=task.handler,
+                            args=(job,),
+                            name=f"{self.__class__.__name__}-Job-{job.type}")
             logger.debug(f"Running job: {job}")
             thread.start()
 


### PR DESCRIPTION
When debugging, being able to see which threads was created by PyZeebe can be helpful

![image](https://user-images.githubusercontent.com/24817039/98087902-119c4300-1e81-11eb-8863-60b3e5038738.png)


## Changes

- Give worker threads (task and job) names upon creation

## API Updates

### New Features *(required)*

None

### Deprecations *(required)*

None

### Enhancements *(optional)*

None

## Checklist

- [ ] Unit tests
- [ ] Documentation

## References

None