### PR TITLE
Maintenance/zeebe 0.25.1

### DIFF
--- a/.github/workflows/test-zeebe-integration.yml
+++ b/.github/workflows/test-zeebe-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zeebe-version: [ "0.23.7", "0.24.5", "0.25.1" ]
+        zeebe-version: [ "0.23.7", "0.24.4", "0.25.1" ]
 
     container: python:3.5
 

--- a/.github/workflows/test-zeebe-integration.yml
+++ b/.github/workflows/test-zeebe-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zeebe-version: [ "0.23.6", "0.24.3" ]
+        zeebe-version: [ "0.23.7", "0.24.5", "0.25.1" ]
         python-version: [ 3.5, 3.6, 3.7, 3.8 ]
 
     container: python:${{ matrix.python-version }}

--- a/.github/workflows/test-zeebe-integration.yml
+++ b/.github/workflows/test-zeebe-integration.yml
@@ -14,9 +14,8 @@ jobs:
     strategy:
       matrix:
         zeebe-version: [ "0.23.7", "0.24.5", "0.25.1" ]
-        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
 
-    container: python:${{ matrix.python-version }}
+    container: python:3.5
 
     services:
       zeebe:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Zeebe version support:
 
 | Pyzeebe version | Tested Zeebe versions |
 |:---------------:|----------------|
-| 2.x.x           | 0.23, 0.24         |
+| 2.x.x           | 0.23, 0.24, 0.25         |
 | 1.x.x           | 0.23, 0.24         |
 
 ## Getting Started


### PR DESCRIPTION
Test pyzeebe on zeebe version 0.25

## Changes

- Add integration tests for zeebe version 0.25
- Only use python 3.5 on integration testing

## API Updates
none

### New Features *(required)*
none

### Deprecations *(required)*
none

### Enhancements *(optional)*
-  Integration tests should be faster
- Test zeebe 0.25

## Checklist

- [ ] Unit tests
- [x] Documentation
