### PR TITLE
Bump zeebe versions

### DIFF
--- a/.github/workflows/test-zeebe-integration.yml
+++ b/.github/workflows/test-zeebe-integration.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        zeebe-version: [ "0.23.7", "0.24.4", "0.25.1" ]
+        zeebe-version: [ "0.23.7", "0.24.6", "0.25.3" ]
 
     container: python:3.5
 


### PR DESCRIPTION
Bump zeebe versions to latest release.
 
## Changes

- Bump zeebe version for integration tests
  - all supported versions (0.23, 0.24, 0.25)

## API Updates

none

### New Features *(required)*

none

### Deprecations *(required)*

none

### Enhancements *(optional)*

Testing against latest versions of zeebe.

## Checklist

- [ ] Unit tests
- [ ] Documentation
