### PR TITLE
Bump minimum python version to 3.6

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     
     container: python:${{ matrix.python-version }}
     steps:

--- a/.github/workflows/test-zeebe-integration.yml
+++ b/.github/workflows/test-zeebe-integration.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         zeebe-version: [ "0.23.7", "0.24.4", "0.25.1" ]
 
-    container: python:3.5
+    container: python:3.6
 
     services:
       zeebe:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ Creating a client
 Dependencies
 ============
 
-* python 3.5+
+* python 3.6+
 * zeebe-grpc
 * grpcio
 * protobuf

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
Remove support for python3.5

## Changes

- Minimum required python version is now 3.6

## API Updates

none

### New Features *(required)*

none

### Deprecations *(required)*

Python 3.5 will no longer be supported.

## Checklist

- [x] Unit tests
- [x] Documentation
