### PR TITLE
Suppress Pytest warnings about thread exceptions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::pytest.PytestUnhandledThreadExceptionWarning


### PR DESCRIPTION
After upgrading to pytest 6.2.x (PR https://github.com/JonatanMartens/pyzeebe/pull/90), new warnings are emitted:

![image](https://user-images.githubusercontent.com/24817039/106021863-85876980-60c5-11eb-99cd-544f2bd31820.png)

Test run: https://github.com/JonatanMartens/pyzeebe/pull/90/checks?check_run_id=1562022232#step:5:24

This is new in pytest 6.2: https://docs.pytest.org/en/stable/usage.html#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions

## Changes

Silence `pytest.PytestUnhandledThreadExceptionWarning` that are emitted when running tests.

This is to make the output similar to as it was before 6.2.x. 

_The exceptions are worth being looking into, will create a separate task to handle that (with possible removal of the change introduced here)._


## API Updates

### New Features *(required)*

n/a

### Deprecations *(required)*

n/a

### Enhancements *(optional)*

n/a

## Checklist

- [ n/a ] Unit tests
- [ n/a ] Documentation