### PR TITLE
Refactor/test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyzeebe import ZeebeClient
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 from tests.unit.utils.gateway_mock import GatewayMock
 from tests.unit.utils.random_utils import random_job
@@ -13,6 +14,11 @@ def job():
 @pytest.fixture
 def zeebe_adapter(grpc_channel):
     return ZeebeAdapter(channel=grpc_channel)
+
+
+@pytest.fixture
+def zeebe_client(grpc_channel):
+    return ZeebeClient(channel=grpc_channel)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
+from random import randint
+from uuid import uuid4
+
 import pytest
 
-from pyzeebe import ZeebeClient
+from pyzeebe import ZeebeClient, ZeebeWorker, ZeebeTaskRouter
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
+from pyzeebe.task.task import Task
 from tests.unit.utils.gateway_mock import GatewayMock
 from tests.unit.utils.random_utils import random_job
 
@@ -24,6 +28,26 @@ def zeebe_adapter(grpc_channel):
 @pytest.fixture
 def zeebe_client(grpc_channel):
     return ZeebeClient(channel=grpc_channel)
+
+
+@pytest.fixture
+def zeebe_worker():
+    return ZeebeWorker()
+
+
+@pytest.fixture
+def task():
+    return Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
+
+
+@pytest.fixture
+def router():
+    return ZeebeTaskRouter()
+
+
+@pytest.fixture
+def routers():
+    return [ZeebeTaskRouter() for _ in range(0, randint(2, 100))]
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
+from tests.unit.utils.gateway_mock import GatewayMock
+from tests.unit.utils.random_utils import random_job
+
+
+@pytest.fixture(scope="module")
+def job():
+    return random_job()
+
+
+@pytest.fixture(scope="module")
+def grpc_add_to_server():
+    from zeebe_grpc.gateway_pb2_grpc import add_GatewayServicer_to_server
+    return add_GatewayServicer_to_server
+
+
+@pytest.fixture(scope="module")
+def grpc_servicer():
+    return GatewayMock()
+
+
+@pytest.fixture(scope="module")
+def grpc_stub_cls(grpc_channel):
+    from zeebe_grpc.gateway_pb2_grpc import GatewayStub
+    return GatewayStub
+
+
+@pytest.fixture(scope="module")
+def zeebe_adapter(grpc_channel):
+    return ZeebeAdapter(channel=grpc_channel)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,14 @@ from tests.unit.utils.gateway_mock import GatewayMock
 from tests.unit.utils.random_utils import random_job
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def job():
     return random_job()
+
+
+@pytest.fixture
+def zeebe_adapter(grpc_channel):
+    return ZeebeAdapter(channel=grpc_channel)
 
 
 @pytest.fixture(scope="module")
@@ -25,8 +30,3 @@ def grpc_servicer():
 def grpc_stub_cls(grpc_channel):
     from zeebe_grpc.gateway_pb2_grpc import GatewayStub
     return GatewayStub
-
-
-@pytest.fixture(scope="module")
-def zeebe_adapter(grpc_channel):
-    return ZeebeAdapter(channel=grpc_channel)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,18 +22,20 @@ def job_without_adapter():
 
 
 @pytest.fixture
-def zeebe_adapter(grpc_channel):
-    return ZeebeAdapter(channel=grpc_channel)
+def zeebe_adapter(grpc_create_channel):
+    return ZeebeAdapter(channel=grpc_create_channel())
 
 
 @pytest.fixture
-def zeebe_client(grpc_channel):
-    return ZeebeClient(channel=grpc_channel)
+def zeebe_client(grpc_create_channel):
+    return ZeebeClient(channel=grpc_create_channel())
 
 
 @pytest.fixture
-def zeebe_worker():
-    return ZeebeWorker()
+def zeebe_worker(zeebe_adapter):
+    worker = ZeebeWorker()
+    worker.zeebe_adapter = zeebe_adapter
+    return worker
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,12 @@ from tests.unit.utils.random_utils import random_job
 
 
 @pytest.fixture
-def job():
+def job_with_adapter(zeebe_adapter):
+    return random_job(zeebe_adapter=zeebe_adapter)
+
+
+@pytest.fixture
+def job_without_adapter():
     return random_job()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from pyzeebe import ZeebeClient, ZeebeWorker, ZeebeTaskRouter
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 from pyzeebe.task.task import Task
+from pyzeebe.worker.task_handler import ZeebeTaskHandler
 from tests.unit.utils.gateway_mock import GatewayMock
 from tests.unit.utils.random_utils import random_job
 
@@ -48,6 +49,11 @@ def router():
 @pytest.fixture
 def routers():
     return [ZeebeTaskRouter() for _ in range(0, randint(2, 100))]
+
+
+@pytest.fixture
+def task_handler():
+    return ZeebeTaskHandler()
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/client/client_test.py
+++ b/tests/unit/client/client_test.py
@@ -4,52 +4,41 @@ from uuid import uuid4
 
 import pytest
 
-from pyzeebe.client.client import ZeebeClient
 from pyzeebe.exceptions import WorkflowNotFound
 
-zeebe_client: ZeebeClient
 
-
-@pytest.fixture(autouse=True)
-def run_around_tests(grpc_channel):
-    global zeebe_client
-    zeebe_client = ZeebeClient(channel=grpc_channel)
-    yield
-    zeebe_client = ZeebeClient(channel=grpc_channel)
-
-
-def test_run_workflow(grpc_servicer):
+def test_run_workflow(zeebe_client, grpc_servicer):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
     assert isinstance(zeebe_client.run_workflow(bpmn_process_id=bpmn_process_id, variables={}, version=version), int)
 
 
-def test_run_workflow_with_result(grpc_servicer):
+def test_run_workflow_with_result(zeebe_client, grpc_servicer):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
     assert isinstance(zeebe_client.run_workflow(bpmn_process_id=bpmn_process_id, variables={}, version=version), int)
 
 
-def test_deploy_workflow():
+def test_deploy_workflow(zeebe_client):
     zeebe_client.zeebe_adapter.deploy_workflow = MagicMock()
     file_path = str(uuid4())
     zeebe_client.deploy_workflow(file_path)
     zeebe_client.zeebe_adapter.deploy_workflow.assert_called_with(file_path)
 
 
-def test_run_non_existent_workflow():
+def test_run_non_existent_workflow(zeebe_client):
     with pytest.raises(WorkflowNotFound):
         zeebe_client.run_workflow(bpmn_process_id=str(uuid4()))
 
 
-def test_run_non_existent_workflow_with_result():
+def test_run_non_existent_workflow_with_result(zeebe_client):
     with pytest.raises(WorkflowNotFound):
         zeebe_client.run_workflow_with_result(bpmn_process_id=str(uuid4()))
 
 
-def test_cancel_workflow_instance(grpc_servicer):
+def test_cancel_workflow_instance(zeebe_client, grpc_servicer):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
@@ -57,5 +46,5 @@ def test_cancel_workflow_instance(grpc_servicer):
     assert isinstance(zeebe_client.cancel_workflow_instance(workflow_instance_key=workflow_instance_key), int)
 
 
-def test_publish_message():
+def test_publish_message(zeebe_client):
     zeebe_client.publish_message(name=str(uuid4()), correlation_key=str(uuid4()))

--- a/tests/unit/client/client_test.py
+++ b/tests/unit/client/client_test.py
@@ -2,9 +2,10 @@ from random import randint
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 from pyzeebe.client.client import ZeebeClient
 from pyzeebe.exceptions import WorkflowNotFound
-from tests.unit.utils.grpc_utils import *
 
 zeebe_client: ZeebeClient
 

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -101,8 +101,7 @@ def test_with_secure_connection(zeebe_adapter):
 
 
 def test_with_camunda_cloud_credentials(zeebe_adapter):
-    CamundaCloudCredentials.get_access_token = MagicMock()
-    CamundaCloudCredentials.get_access_token.return_value = str(uuid4())
+    CamundaCloudCredentials.get_access_token = MagicMock(return_value=str(uuid4()))
     credentials = CamundaCloudCredentials(str(uuid4()), str(uuid4()), str(uuid4()))
 
     with patch("grpc.secure_channel") as grpc_secure_channel_mock:
@@ -114,8 +113,7 @@ def test_credentials_connection_uri_gotten(zeebe_adapter):
     client_id = str(uuid4())
     client_secret = str(uuid4())
     cluster_id = str(uuid4())
-    CamundaCloudCredentials.get_access_token = MagicMock()
-    CamundaCloudCredentials.get_access_token.return_value = str(uuid4())
+    CamundaCloudCredentials.get_access_token = MagicMock(return_value=str(uuid4()))
     credentials = CamundaCloudCredentials(client_id, client_secret, cluster_id)
     zeebe_adapter = ZeebeAdapterBase(credentials=credentials)
     assert zeebe_adapter.connection_uri == f"{cluster_id}.zeebe.camunda.io:443"

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -2,11 +2,14 @@ from random import randint
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
+import grpc
+import pytest
+
 from pyzeebe.credentials.camunda_cloud_credentials import CamundaCloudCredentials
 from pyzeebe.credentials.oauth_credentials import OAuthCredentials
 from pyzeebe.exceptions import ZeebeBackPressure, ZeebeGatewayUnavailable, ZeebeInternalError
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
-from tests.unit.utils.grpc_utils import *
+from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
 zeebe_adapter: ZeebeAdapterBase

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -12,43 +12,33 @@ from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
-zeebe_adapter: ZeebeAdapterBase
 
-
-@pytest.fixture(autouse=True)
-def run_around_tests(grpc_channel):
-    global zeebe_adapter
-    zeebe_adapter = ZeebeAdapterBase(channel=grpc_channel)
-    yield
-    zeebe_adapter = ZeebeAdapterBase(channel=grpc_channel)
-
-
-def test_connectivity_ready():
+def test_connectivity_ready(zeebe_adapter):
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.READY)
     assert not zeebe_adapter.retrying_connection
     assert zeebe_adapter.connected
 
 
-def test_connectivity_transient_idle():
+def test_connectivity_transient_idle(zeebe_adapter):
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.IDLE)
     assert not zeebe_adapter.retrying_connection
     assert zeebe_adapter.connected
 
 
-def test_connectivity_connecting():
+def test_connectivity_connecting(zeebe_adapter):
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.CONNECTING)
     assert zeebe_adapter.retrying_connection
     assert not zeebe_adapter.connected
 
 
-def test_connectivity_transient_failure_retry():
+def test_connectivity_transient_failure_retry(zeebe_adapter):
     zeebe_adapter._max_connection_retries = 1
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
     assert zeebe_adapter.retrying_connection
     assert not zeebe_adapter.connected
 
 
-def test_connectivity_transient_failure_no_retry():
+def test_connectivity_transient_failure_no_retry(zeebe_adapter):
     zeebe_adapter._max_connection_retries = 0
     zeebe_adapter._channel.close = MagicMock()
     with pytest.raises(ConnectionAbortedError):
@@ -56,7 +46,7 @@ def test_connectivity_transient_failure_no_retry():
         zeebe_adapter._channel.close.assert_called_once()
 
 
-def test_connectivity_transient_failure_logs_warning(caplog):
+def test_connectivity_transient_failure_logs_warning(caplog, zeebe_adapter):
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
     expected_logger = "pyzeebe.grpc_internals.zeebe_adapter_base"
     expected_level = "WARNING"
@@ -68,49 +58,49 @@ def test_connectivity_transient_failure_logs_warning(caplog):
     assert len(matching_logs) > 0
 
 
-def test_connectivity_shutdown():
+def test_connectivity_shutdown(zeebe_adapter):
     zeebe_adapter._check_connectivity(grpc.ChannelConnectivity.SHUTDOWN)
     assert not zeebe_adapter.connected
     assert not zeebe_adapter.retrying_connection
 
 
-def test_should_retry_no_current_retries():
+def test_should_retry_no_current_retries(zeebe_adapter):
     zeebe_adapter._max_connection_retries = 1
     assert zeebe_adapter._should_retry()
 
 
-def test_should_retry_current_retries_over_max():
+def test_should_retry_current_retries_over_max(zeebe_adapter):
     zeebe_adapter._max_connection_retries = 1
     zeebe_adapter._current_connection_retries = 1
     assert not zeebe_adapter._should_retry()
 
 
-def test_only_port():
+def test_only_port(zeebe_adapter):
     port = randint(0, 10000)
     zeebe_adapter = ZeebeAdapterBase(port=port)
     assert zeebe_adapter.connection_uri == f"localhost:{port}"
 
 
-def test_only_host():
+def test_only_host(zeebe_adapter):
     hostname = str(uuid4())
     zeebe_adapter = ZeebeAdapterBase(hostname=hostname)
     assert zeebe_adapter.connection_uri == f"{hostname}:26500"
 
 
-def test_host_and_port():
+def test_host_and_port(zeebe_adapter):
     hostname = str(uuid4())
     port = randint(0, 10000)
     zeebe_adapter = ZeebeAdapterBase(hostname=hostname, port=port)
     assert zeebe_adapter.connection_uri == f"{hostname}:{port}"
 
 
-def test_with_secure_connection():
+def test_with_secure_connection(zeebe_adapter):
     with patch("grpc.secure_channel") as grpc_secure_channel_mock:
         ZeebeAdapterBase(secure_connection=True)
         grpc_secure_channel_mock.assert_called()
 
 
-def test_with_camunda_cloud_credentials():
+def test_with_camunda_cloud_credentials(zeebe_adapter):
     CamundaCloudCredentials.get_access_token = MagicMock()
     CamundaCloudCredentials.get_access_token.return_value = str(uuid4())
     credentials = CamundaCloudCredentials(str(uuid4()), str(uuid4()), str(uuid4()))
@@ -120,7 +110,7 @@ def test_with_camunda_cloud_credentials():
         grpc_secure_channel_mock.assert_called()
 
 
-def test_credentials_connection_uri_gotten():
+def test_credentials_connection_uri_gotten(zeebe_adapter):
     client_id = str(uuid4())
     client_secret = str(uuid4())
     cluster_id = str(uuid4())
@@ -131,7 +121,7 @@ def test_credentials_connection_uri_gotten():
     assert zeebe_adapter.connection_uri == f"{cluster_id}.zeebe.camunda.io:443"
 
 
-def test_credentials_no_connection_uri():
+def test_credentials_no_connection_uri(zeebe_adapter):
     hostname = str(uuid4())
     port = randint(0, RANDOM_RANGE)
     url = f"https://{str(uuid4())}/oauth/token"
@@ -145,35 +135,35 @@ def test_credentials_no_connection_uri():
     assert zeebe_adapter.connection_uri == f"{hostname}:{port}"
 
 
-def test_common_zeebe_grpc_error_internal():
+def test_common_zeebe_grpc_error_internal(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
     with pytest.raises(ZeebeInternalError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
-def test_common_zeebe_grpc_error_back_pressure():
+def test_common_zeebe_grpc_error_back_pressure(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.RESOURCE_EXHAUSTED)
     with pytest.raises(ZeebeBackPressure):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
-def test_common_zeebe_grpc_error_gateway_unavailable():
+def test_common_zeebe_grpc_error_gateway_unavailable(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
     with pytest.raises(ZeebeGatewayUnavailable):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
-def test_common_zeebe_grpc_error_unkown_error():
+def test_common_zeebe_grpc_error_unkown_error(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode("Nothing")
     with pytest.raises(grpc.RpcError):
         zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
-def test_close_after_retried_unavailable():
+def test_close_after_retried_unavailable(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.UNAVAILABLE)
     zeebe_adapter._close = MagicMock()
@@ -184,7 +174,7 @@ def test_close_after_retried_unavailable():
     zeebe_adapter._close.assert_called_once()
 
 
-def test_close_after_retried_internal():
+def test_close_after_retried_internal(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
     zeebe_adapter._close = MagicMock()

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -2,13 +2,15 @@ from random import randint
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import grpc
+import pytest
 from zeebe_grpc.gateway_pb2 import *
 
 from pyzeebe.exceptions import ActivateJobsRequestInvalid, JobAlreadyDeactivated, JobNotFound
 from pyzeebe.grpc_internals.zeebe_job_adapter import ZeebeJobAdapter
 from pyzeebe.job.job import Job
 from pyzeebe.task.task import Task
-from tests.unit.utils.grpc_utils import *
+from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE, random_job
 
 zeebe_job_adapter: ZeebeJobAdapter

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -82,21 +82,6 @@ def test_activate_jobs_common_errors_called(zeebe_adapter):
     zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_throw_error_common_errors_called(zeebe_adapter):
-    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
-    error = grpc.RpcError()
-    error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
-
-    zeebe_adapter._gateway_stub.ActivateJobs = MagicMock(side_effect=error)
-
-    zeebe_adapter.zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()),
-                                                  timeout=randint(10, 100),
-                                                  request_timeout=100, max_jobs_to_activate=0,
-                                                  variables_to_fetch=[])
-
-    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
-
-
 def test_complete_job(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
     job = get_first_active_job(task_type, zeebe_adapter)

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -7,7 +7,6 @@ import pytest
 from zeebe_grpc.gateway_pb2 import *
 
 from pyzeebe.exceptions import ActivateJobsRequestInvalid, JobAlreadyDeactivated, JobNotFound
-from pyzeebe.grpc_internals.zeebe_job_adapter import ZeebeJobAdapter
 from pyzeebe.job.job import Job
 from pyzeebe.task.task import Task
 from tests.unit.utils.grpc_utils import GRPCStatusCode

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -13,8 +13,6 @@ from pyzeebe.task.task import Task
 from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE, random_job
 
-zeebe_job_adapter: ZeebeJobAdapter
-
 
 def create_random_task_and_activate(grpc_servicer, task_type: str = None) -> str:
     if task_type:
@@ -27,184 +25,176 @@ def create_random_task_and_activate(grpc_servicer, task_type: str = None) -> str
     return mock_task_type
 
 
-def get_first_active_job(task_type) -> Job:
-    return next(zeebe_job_adapter.activate_jobs(task_type=task_type, max_jobs_to_activate=1, request_timeout=10,
-                                                timeout=100, variables_to_fetch=[], worker=str(uuid4())))
+def get_first_active_job(task_type, zeebe_adapter) -> Job:
+    return next(zeebe_adapter.activate_jobs(task_type=task_type, max_jobs_to_activate=1, request_timeout=10,
+                                            timeout=100, variables_to_fetch=[], worker=str(uuid4())))
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests(grpc_channel):
-    global zeebe_job_adapter
-    zeebe_job_adapter = ZeebeJobAdapter(channel=grpc_channel)
-    yield
-    zeebe_job_adapter = ZeebeJobAdapter(channel=grpc_channel)
-
-
-def test_activate_jobs(grpc_servicer):
+def test_activate_jobs(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
     active_jobs_count = randint(4, 100)
     counter = 0
     for i in range(0, active_jobs_count):
         create_random_task_and_activate(grpc_servicer, task_type)
 
-    for job in zeebe_job_adapter.activate_jobs(task_type=task_type, worker=str(uuid4()), timeout=randint(10, 100),
-                                               request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]):
+    for job in zeebe_adapter.activate_jobs(task_type=task_type, worker=str(uuid4()), timeout=randint(10, 100),
+                                           request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]):
         counter += 1
         assert isinstance(job, Job)
     assert counter == active_jobs_count + 1
 
 
-def test_activate_jobs_invalid_worker():
+def test_activate_jobs_invalid_worker(zeebe_adapter):
     with pytest.raises(ActivateJobsRequestInvalid):
-        next(zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=None, timeout=randint(10, 100),
-                                             request_timeout=100,
-                                             max_jobs_to_activate=1, variables_to_fetch=[]))
+        next(zeebe_adapter.activate_jobs(task_type=str(uuid4()), worker=None, timeout=randint(10, 100),
+                                         request_timeout=100,
+                                         max_jobs_to_activate=1, variables_to_fetch=[]))
 
 
-def test_activate_jobs_invalid_job_timeout():
+def test_activate_jobs_invalid_job_timeout(zeebe_adapter):
     with pytest.raises(ActivateJobsRequestInvalid):
-        next(zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=0,
-                                             request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]))
+        next(zeebe_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=0,
+                                         request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]))
 
 
-def test_activate_jobs_invalid_task_type():
+def test_activate_jobs_invalid_task_type(zeebe_adapter):
     with pytest.raises(ActivateJobsRequestInvalid):
-        next(zeebe_job_adapter.activate_jobs(task_type=None, worker=str(uuid4()), timeout=randint(10, 100),
-                                             request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]))
+        next(zeebe_adapter.activate_jobs(task_type=None, worker=str(uuid4()), timeout=randint(10, 100),
+                                         request_timeout=100, max_jobs_to_activate=1, variables_to_fetch=[]))
 
 
-def test_activate_jobs_invalid_max_jobs():
+def test_activate_jobs_invalid_max_jobs(zeebe_adapter):
     with pytest.raises(ActivateJobsRequestInvalid):
-        next(zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=randint(10, 100),
-                                             request_timeout=100, max_jobs_to_activate=0, variables_to_fetch=[]))
+        next(zeebe_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=randint(10, 100),
+                                         request_timeout=100, max_jobs_to_activate=0, variables_to_fetch=[]))
 
 
-def test_activate_jobs_common_errors_called(grpc_servicer):
-    zeebe_job_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_activate_jobs_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_job_adapter._gateway_stub.ActivateJobs = MagicMock(side_effect=error)
-    jobs = zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=randint(10, 100),
-                                           request_timeout=100, max_jobs_to_activate=0, variables_to_fetch=[])
+    zeebe_adapter._gateway_stub.ActivateJobs = MagicMock(side_effect=error)
+    jobs = zeebe_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()), timeout=randint(10, 100),
+                                       request_timeout=100, max_jobs_to_activate=0, variables_to_fetch=[])
     for job in jobs:
         raise Exception(f"This should not return jobs! Job: {job}")
 
-    zeebe_job_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_throw_error_common_errors_called(grpc_servicer):
-    zeebe_job_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_throw_error_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_job_adapter._gateway_stub.ActivateJobs = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.ActivateJobs = MagicMock(side_effect=error)
 
-    zeebe_job_adapter.zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()),
-                                                      timeout=randint(10, 100),
-                                                      request_timeout=100, max_jobs_to_activate=0,
-                                                      variables_to_fetch=[])
+    zeebe_adapter.zeebe_job_adapter.activate_jobs(task_type=str(uuid4()), worker=str(uuid4()),
+                                                  timeout=randint(10, 100),
+                                                  request_timeout=100, max_jobs_to_activate=0,
+                                                  variables_to_fetch=[])
 
-    zeebe_job_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_complete_job(grpc_servicer):
+def test_complete_job(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    response = zeebe_job_adapter.complete_job(job_key=job.key, variables={})
+    job = get_first_active_job(task_type, zeebe_adapter)
+    response = zeebe_adapter.complete_job(job_key=job.key, variables={})
     assert isinstance(response, CompleteJobResponse)
 
 
-def test_complete_job_not_found(grpc_servicer):
+def test_complete_job_not_found(zeebe_adapter):
     with pytest.raises(JobNotFound):
-        zeebe_job_adapter.complete_job(job_key=randint(0, RANDOM_RANGE), variables={})
+        zeebe_adapter.complete_job(job_key=randint(0, RANDOM_RANGE), variables={})
 
 
-def test_complete_job_already_completed(grpc_servicer):
+def test_complete_job_already_completed(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.complete_job(job_key=job.key, variables={})
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.complete_job(job_key=job.key, variables={})
     with pytest.raises(JobAlreadyDeactivated):
-        zeebe_job_adapter.complete_job(job_key=job.key, variables={})
+        zeebe_adapter.complete_job(job_key=job.key, variables={})
 
 
-def test_complete_job_common_errors_called(grpc_servicer):
-    zeebe_job_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_complete_job_common_errors_called(zeebe_adapter, grpc_servicer):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_job_adapter._gateway_stub.CompleteJob = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.CompleteJob = MagicMock(side_effect=error)
 
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.complete_job(job_key=job.key, variables={})
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.complete_job(job_key=job.key, variables={})
 
-    zeebe_job_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_fail_job(grpc_servicer):
+def test_fail_job(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    response = zeebe_job_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    response = zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
     assert isinstance(response, FailJobResponse)
 
 
-def test_fail_job_not_found():
+def test_fail_job_not_found(zeebe_adapter):
     with pytest.raises(JobNotFound):
-        zeebe_job_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
 
 
-def test_fail_job_already_failed(grpc_servicer):
+def test_fail_job_already_failed(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
     with pytest.raises(JobAlreadyDeactivated):
-        zeebe_job_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
 
 
-def test_fail_job_common_errors_called(grpc_servicer):
-    zeebe_job_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_fail_job_common_errors_called(zeebe_adapter, grpc_servicer):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_job_adapter._gateway_stub.FailJob = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.FailJob = MagicMock(side_effect=error)
 
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
 
-    zeebe_job_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_throw_error(grpc_servicer):
+def test_throw_error(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    response = zeebe_job_adapter.throw_error(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    response = zeebe_adapter.throw_error(job_key=job.key, message=str(uuid4()))
     assert isinstance(response, ThrowErrorResponse)
 
 
-def test_throw_error_job_not_found():
+def test_throw_error_job_not_found(zeebe_adapter):
     with pytest.raises(JobNotFound):
-        zeebe_job_adapter.throw_error(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
+        zeebe_adapter.throw_error(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
 
 
-def test_throw_error_already_thrown(grpc_servicer):
+def test_throw_error_already_thrown(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.throw_error(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.throw_error(job_key=job.key, message=str(uuid4()))
     with pytest.raises(JobAlreadyDeactivated):
-        zeebe_job_adapter.throw_error(job_key=job.key, message=str(uuid4()))
+        zeebe_adapter.throw_error(job_key=job.key, message=str(uuid4()))
 
 
-def test_throw_error_common_errors_called(grpc_servicer):
-    zeebe_job_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_throw_error_common_errors_called(zeebe_adapter, grpc_servicer):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_job_adapter._gateway_stub.ThrowError = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.ThrowError = MagicMock(side_effect=error)
 
     task_type = create_random_task_and_activate(grpc_servicer)
-    job = get_first_active_job(task_type)
-    zeebe_job_adapter.throw_error(job_key=job.key, message=str(uuid4()))
+    job = get_first_active_job(task_type, zeebe_adapter)
+    zeebe_adapter.throw_error(job_key=job.key, message=str(uuid4()))
 
-    zeebe_job_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()

--- a/tests/unit/grpc_internals/zeebe_message_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_message_adapter_test.py
@@ -2,11 +2,13 @@ from random import randint
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import grpc
+import pytest
 from zeebe_grpc.gateway_pb2 import *
 
 from pyzeebe.exceptions import MessageAlreadyExists
 from pyzeebe.grpc_internals.zeebe_message_adapter import ZeebeMessageAdapter
-from tests.unit.utils.grpc_utils import *
+from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
 zeebe_message_adapter: ZeebeMessageAdapter

--- a/tests/unit/grpc_internals/zeebe_message_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_message_adapter_test.py
@@ -7,63 +7,52 @@ import pytest
 from zeebe_grpc.gateway_pb2 import *
 
 from pyzeebe.exceptions import MessageAlreadyExists
-from pyzeebe.grpc_internals.zeebe_message_adapter import ZeebeMessageAdapter
 from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
-zeebe_message_adapter: ZeebeMessageAdapter
 
-
-@pytest.fixture(autouse=True)
-def run_around_tests(grpc_channel):
-    global zeebe_message_adapter
-    zeebe_message_adapter = ZeebeMessageAdapter(channel=grpc_channel)
-    yield
-    zeebe_message_adapter = ZeebeMessageAdapter(channel=grpc_channel)
-
-
-def test_publish_message():
-    response = zeebe_message_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
-                                                     time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+def test_publish_message(zeebe_adapter):
+    response = zeebe_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
+                                             time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
     assert isinstance(response, PublishMessageResponse)
 
 
-def test_punlish_message_invalid_name():
+def test_publish_message_invalid_name(zeebe_adapter):
     with pytest.raises(TypeError):
-        zeebe_message_adapter.publish_message(name=randint(0, RANDOM_RANGE), variables={}, correlation_key=str(uuid4()),
-                                              time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+        zeebe_adapter.publish_message(name=randint(0, RANDOM_RANGE), variables={}, correlation_key=str(uuid4()),
+                                      time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
 
 
-def test_publish_message_invalid_correlation_key():
+def test_publish_message_invalid_correlation_key(zeebe_adapter):
     with pytest.raises(TypeError):
-        zeebe_message_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=randint(0, RANDOM_RANGE),
-                                              time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+        zeebe_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=randint(0, RANDOM_RANGE),
+                                      time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
 
 
-def test_punlish_message_invalid_time_to_live():
+def test_punlish_message_invalid_time_to_live(zeebe_adapter):
     with pytest.raises(TypeError):
-        zeebe_message_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
-                                              time_to_live_in_milliseconds=str(uuid4()))
+        zeebe_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
+                                      time_to_live_in_milliseconds=str(uuid4()))
 
 
-def test_publish_message_already_exists():
+def test_publish_message_already_exists(zeebe_adapter):
     message_id = str(uuid4())
     with pytest.raises(MessageAlreadyExists):
-        zeebe_message_adapter.publish_message(message_id=message_id, name=str(uuid4()), variables={},
-                                              correlation_key=str(uuid4()),
-                                              time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
-        zeebe_message_adapter.publish_message(message_id=message_id, name=str(uuid4()), variables={},
-                                              correlation_key=str(uuid4()),
-                                              time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+        zeebe_adapter.publish_message(message_id=message_id, name=str(uuid4()), variables={},
+                                      correlation_key=str(uuid4()),
+                                      time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+        zeebe_adapter.publish_message(message_id=message_id, name=str(uuid4()), variables={},
+                                      correlation_key=str(uuid4()),
+                                      time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
 
 
-def test_publish_message_common_errors_called():
-    zeebe_message_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_publish_message_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_message_adapter._gateway_stub.PublishMessage = MagicMock(side_effect=error)
-    zeebe_message_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
-                                          time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
+    zeebe_adapter._gateway_stub.PublishMessage = MagicMock(side_effect=error)
+    zeebe_adapter.publish_message(name=str(uuid4()), variables={}, correlation_key=str(uuid4()),
+                                  time_to_live_in_milliseconds=randint(0, RANDOM_RANGE))
 
-    zeebe_message_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()

--- a/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
@@ -8,161 +8,150 @@ import pytest
 
 from pyzeebe.exceptions import InvalidJSON, WorkflowNotFound, WorkflowInstanceNotFound, WorkflowHasNoStartEvent, \
     WorkflowInvalid
-from pyzeebe.grpc_internals.zeebe_workflow_adapter import ZeebeWorkflowAdapter
 from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
-zeebe_workflow_adapter: ZeebeWorkflowAdapter
 
-
-@pytest.fixture(autouse=True)
-def run_around_tests(grpc_channel):
-    global zeebe_workflow_adapter
-    zeebe_workflow_adapter = ZeebeWorkflowAdapter(channel=grpc_channel)
-    yield
-    zeebe_workflow_adapter = ZeebeWorkflowAdapter(channel=grpc_channel)
-
-
-def test_create_workflow_instance(grpc_servicer):
+def test_create_workflow_instance(grpc_servicer, zeebe_adapter):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    response = zeebe_workflow_adapter.create_workflow_instance(bpmn_process_id=bpmn_process_id, variables={},
-                                                               version=version)
+    response = zeebe_adapter.create_workflow_instance(bpmn_process_id=bpmn_process_id, variables={},
+                                                      version=version)
     assert isinstance(response, int)
 
 
-def test_create_workflow_instance_common_errors_called(grpc_servicer):
-    zeebe_workflow_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_create_workflow_instance_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_workflow_adapter._gateway_stub.CreateWorkflowInstance = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.CreateWorkflowInstance = MagicMock(side_effect=error)
 
-    zeebe_workflow_adapter.create_workflow_instance(bpmn_process_id=str(uuid4()), variables={},
-                                                    version=randint(0, 10))
+    zeebe_adapter.create_workflow_instance(bpmn_process_id=str(uuid4()), variables={},
+                                           version=randint(0, 10))
 
-    zeebe_workflow_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_create_workflow_instance_with_result(grpc_servicer):
+def test_create_workflow_instance_with_result(grpc_servicer, zeebe_adapter):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    response = zeebe_workflow_adapter.create_workflow_instance_with_result(bpmn_process_id=bpmn_process_id,
-                                                                           variables={},
-                                                                           version=version, timeout=0,
-                                                                           variables_to_fetch=[])
+    response = zeebe_adapter.create_workflow_instance_with_result(bpmn_process_id=bpmn_process_id,
+                                                                  variables={},
+                                                                  version=version, timeout=0,
+                                                                  variables_to_fetch=[])
     assert isinstance(response, dict)
 
 
-def test_create_workflow_instance_with_result_common_errors_called():
-    zeebe_workflow_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_create_workflow_instance_with_result_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_workflow_adapter._gateway_stub.CreateWorkflowInstanceWithResult = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.CreateWorkflowInstanceWithResult = MagicMock(side_effect=error)
 
-    zeebe_workflow_adapter.create_workflow_instance_with_result(bpmn_process_id=str(uuid4()), variables={},
-                                                                version=randint(0, 10), timeout=0,
-                                                                variables_to_fetch=[])
+    zeebe_adapter.create_workflow_instance_with_result(bpmn_process_id=str(uuid4()), variables={},
+                                                       version=randint(0, 10), timeout=0,
+                                                       variables_to_fetch=[])
 
-    zeebe_workflow_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_cancel_workflow(grpc_servicer):
+def test_cancel_workflow(grpc_servicer, zeebe_adapter):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    workflow_instance_key = zeebe_workflow_adapter.create_workflow_instance(bpmn_process_id=bpmn_process_id,
-                                                                            variables={}, version=version)
-    zeebe_workflow_adapter.cancel_workflow_instance(workflow_instance_key=workflow_instance_key)
+    workflow_instance_key = zeebe_adapter.create_workflow_instance(bpmn_process_id=bpmn_process_id,
+                                                                   variables={}, version=version)
+    zeebe_adapter.cancel_workflow_instance(workflow_instance_key=workflow_instance_key)
     assert workflow_instance_key not in grpc_servicer.active_workflows.keys()
 
 
-def test_cancel_workflow_instance_already_cancelled():
+def test_cancel_workflow_instance_already_cancelled(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.NOT_FOUND)
 
-    zeebe_workflow_adapter._gateway_stub.CancelWorkflowInstance = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.CancelWorkflowInstance = MagicMock(side_effect=error)
 
     with pytest.raises(WorkflowInstanceNotFound):
-        zeebe_workflow_adapter.cancel_workflow_instance(workflow_instance_key=randint(0, RANDOM_RANGE))
+        zeebe_adapter.cancel_workflow_instance(workflow_instance_key=randint(0, RANDOM_RANGE))
 
 
-def test_cancel_workflow_instance_common_errors_called():
-    zeebe_workflow_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_cancel_workflow_instance_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-    zeebe_workflow_adapter._gateway_stub.CancelWorkflowInstance = MagicMock(side_effect=error)
+    zeebe_adapter._gateway_stub.CancelWorkflowInstance = MagicMock(side_effect=error)
 
-    zeebe_workflow_adapter.cancel_workflow_instance(workflow_instance_key=randint(0, RANDOM_RANGE))
+    zeebe_adapter.cancel_workflow_instance(workflow_instance_key=randint(0, RANDOM_RANGE))
 
-    zeebe_workflow_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_deploy_workflow_workflow_invalid(grpc_servicer):
+def test_deploy_workflow_workflow_invalid(zeebe_adapter):
     with patch("builtins.open") as mock_open:
         mock_open.return_value = BytesIO()
 
         error = grpc.RpcError()
         error._state = GRPCStatusCode(grpc.StatusCode.INVALID_ARGUMENT)
 
-        zeebe_workflow_adapter._gateway_stub.DeployWorkflow = MagicMock(side_effect=error)
+        zeebe_adapter._gateway_stub.DeployWorkflow = MagicMock(side_effect=error)
 
         with pytest.raises(WorkflowInvalid):
-            zeebe_workflow_adapter.deploy_workflow()
+            zeebe_adapter.deploy_workflow()
 
 
-def test_deploy_workflow_common_errors_called(grpc_servicer):
+def test_deploy_workflow_common_errors_called(zeebe_adapter):
     with patch("builtins.open") as mock_open:
         mock_open.return_value = BytesIO()
 
-        zeebe_workflow_adapter._common_zeebe_grpc_errors = MagicMock()
+        zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
         error = grpc.RpcError()
         error._state = GRPCStatusCode(grpc.StatusCode.INTERNAL)
 
-        zeebe_workflow_adapter._gateway_stub.DeployWorkflow = MagicMock(side_effect=error)
+        zeebe_adapter._gateway_stub.DeployWorkflow = MagicMock(side_effect=error)
 
-        zeebe_workflow_adapter.deploy_workflow()
+        zeebe_adapter.deploy_workflow()
 
-        zeebe_workflow_adapter._common_zeebe_grpc_errors.assert_called()
+        zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_get_workflow_request_object():
+def test_get_workflow_request_object(zeebe_adapter):
     with patch("builtins.open") as mock_open:
         mock_open.return_value = BytesIO()
         file_path = str(uuid4())
-        zeebe_workflow_adapter._get_workflow_request_object(file_path)
+        zeebe_adapter._get_workflow_request_object(file_path)
         mock_open.assert_called_with(file_path, "rb")
 
 
-def test_create_workflow_errors_not_found():
+def test_create_workflow_errors_not_found(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.NOT_FOUND)
     with pytest.raises(WorkflowNotFound):
-        zeebe_workflow_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
+        zeebe_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
 
 
-def test_create_workflow_errors_invalid_json():
+def test_create_workflow_errors_invalid_json(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.INVALID_ARGUMENT)
     with pytest.raises(InvalidJSON):
-        zeebe_workflow_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
+        zeebe_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
 
 
-def test_create_workflow_errors_workflow_has_no_start_event():
+def test_create_workflow_errors_workflow_has_no_start_event(zeebe_adapter):
     error = grpc.RpcError()
     error._state = GRPCStatusCode(grpc.StatusCode.FAILED_PRECONDITION)
     with pytest.raises(WorkflowHasNoStartEvent):
-        zeebe_workflow_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
+        zeebe_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
 
 
-def test_create_workflow_errors_common_errors_called():
-    zeebe_workflow_adapter._common_zeebe_grpc_errors = MagicMock()
+def test_create_workflow_errors_common_errors_called(zeebe_adapter):
+    zeebe_adapter._common_zeebe_grpc_errors = MagicMock()
     error = grpc.RpcError()
     error._state = GRPCStatusCode("test")
-    zeebe_workflow_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
+    zeebe_adapter._create_workflow_errors(error, str(uuid4()), randint(0, 10, ), {})
 
-    zeebe_workflow_adapter._common_zeebe_grpc_errors.assert_called()
+    zeebe_adapter._common_zeebe_grpc_errors.assert_called()

--- a/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
@@ -3,10 +3,13 @@ from random import randint
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
+import grpc
+import pytest
+
 from pyzeebe.exceptions import InvalidJSON, WorkflowNotFound, WorkflowInstanceNotFound, WorkflowHasNoStartEvent, \
     WorkflowInvalid
 from pyzeebe.grpc_internals.zeebe_workflow_adapter import ZeebeWorkflowAdapter
-from tests.unit.utils.grpc_utils import *
+from tests.unit.utils.grpc_utils import GRPCStatusCode
 from tests.unit.utils.random_utils import RANDOM_RANGE
 
 zeebe_workflow_adapter: ZeebeWorkflowAdapter

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -4,63 +4,40 @@ from uuid import uuid4
 import pytest
 
 from pyzeebe.exceptions import NoZeebeAdapter
-from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
-from pyzeebe.job.job import Job
-from tests.unit.utils.random_utils import random_job
-
-job: Job
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    zeebe_adapter = ZeebeAdapter()
-    global job
-    job = random_job(zeebe_adapter=zeebe_adapter)
-    yield
-    job = random_job(zeebe_adapter=zeebe_adapter)
-
-
-def test_success():
+def test_success(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.complete_job") as complete_job_mock:
-        job.set_success_status()
-        complete_job_mock.assert_called_with(job_key=job.key, variables=job.variables)
+        job_with_adapter.set_success_status()
+        complete_job_mock.assert_called_with(job_key=job_with_adapter.key, variables=job_with_adapter.variables)
 
 
-def test_success_no_zeebe_adapter():
-    global job
-    job = random_job()
-
+def test_success_no_zeebe_adapter(job_without_adapter):
     with pytest.raises(NoZeebeAdapter):
-        job.set_success_status()
+        job_without_adapter.set_success_status()
 
 
-def test_error():
+def test_error(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
         message = str(uuid4())
-        job.set_error_status(message)
-        throw_error_mock.assert_called_with(job_key=job.key, message=message)
+        job_with_adapter.set_error_status(message)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
 
 
-def test_error_no_zeebe_adapter():
-    global job
-    job = random_job()
-
+def test_error_no_zeebe_adapter(job_without_adapter):
     with pytest.raises(NoZeebeAdapter):
         message = str(uuid4())
-        job.set_error_status(message)
+        job_without_adapter.set_error_status(message)
 
 
-def test_failure():
+def test_failure(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.fail_job") as fail_job_mock:
         message = str(uuid4())
-        job.set_failure_status(message)
-        fail_job_mock.assert_called_with(job_key=job.key, message=message)
+        job_with_adapter.set_failure_status(message)
+        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
 
 
-def test_failure_no_zeebe_adapter():
-    global job
-    job = random_job()
-
+def test_failure_no_zeebe_adapter(job_without_adapter):
     with pytest.raises(NoZeebeAdapter):
         message = str(uuid4())
-        job.set_failure_status(message)
+        job_without_adapter.set_failure_status(message)

--- a/tests/unit/utils/grpc_utils.py
+++ b/tests/unit/utils/grpc_utils.py
@@ -1,24 +1,4 @@
 import grpc
-import pytest
-
-from tests.unit.utils.gateway_mock import GatewayMock
-
-
-@pytest.fixture(scope="module")
-def grpc_add_to_server():
-    from zeebe_grpc.gateway_pb2_grpc import add_GatewayServicer_to_server
-    return add_GatewayServicer_to_server
-
-
-@pytest.fixture(scope="module")
-def grpc_servicer():
-    return GatewayMock()
-
-
-@pytest.fixture(scope="module")
-def grpc_stub_cls(grpc_channel):
-    from zeebe_grpc.gateway_pb2_grpc import GatewayStub
-    return GatewayStub
 
 
 class GRPCStatusCode:

--- a/tests/unit/worker/task_handler_test.py
+++ b/tests/unit/worker/task_handler_test.py
@@ -1,190 +1,178 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
 import pytest
 
 from pyzeebe.exceptions import NoVariableNameGiven, TaskNotFound, DuplicateTaskType
 from pyzeebe.task.task import Task
-from pyzeebe.worker.task_handler import ZeebeTaskHandler, default_exception_handler
-from tests.unit.utils.random_utils import randint, random_job
-
-zeebe_task_handler: ZeebeTaskHandler
-task: Task
+from pyzeebe.worker.task_handler import default_exception_handler
+from tests.unit.utils.random_utils import randint
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    global zeebe_task_handler, task
-    task = Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
-    zeebe_task_handler = ZeebeTaskHandler()
-    yield
-    zeebe_task_handler = ZeebeTaskHandler()
-    task = Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
-
-
-def test_get_task():
-    zeebe_task_handler.tasks.append(task)
-    found_task = zeebe_task_handler.get_task(task.type)
+def test_get_task(task_handler, task):
+    task_handler.tasks.append(task)
+    found_task = task_handler.get_task(task.type)
     assert isinstance(found_task, Task)
     assert found_task == task
 
 
-def test_get_fake_task():
+def test_get_fake_task(task_handler):
     with pytest.raises(TaskNotFound):
-        zeebe_task_handler.get_task(str(uuid4()))
+        task_handler.get_task(str(uuid4()))
 
 
-def test_get_task_index():
-    zeebe_task_handler.tasks.append(task)
-    index = zeebe_task_handler._get_task_index(task.type)
+def test_get_task_index(task_handler, task):
+    task_handler.tasks.append(task)
+    index = task_handler._get_task_index(task.type)
     assert isinstance(index, int)
-    assert zeebe_task_handler.tasks[index] == task
+    assert task_handler.tasks[index] == task
 
 
-def test_get_task_and_index():
-    zeebe_task_handler.tasks.append(task)
-    found_task, index = zeebe_task_handler._get_task_and_index(task.type)
+def test_get_task_and_index(task_handler, task):
+    task_handler.tasks.append(task)
+    found_task, index = task_handler._get_task_and_index(task.type)
     assert isinstance(index, int)
-    assert zeebe_task_handler.tasks[index] == task
+    assert task_handler.tasks[index] == task
     assert isinstance(found_task, Task)
     assert found_task == task
 
 
-def test_remove_task():
-    zeebe_task_handler.tasks.append(task)
-    assert zeebe_task_handler.remove_task(task.type) is not None
-    assert task not in zeebe_task_handler.tasks
+def test_remove_task(task_handler, task):
+    task_handler.tasks.append(task)
+    assert task_handler.remove_task(task.type) is not None
+    assert task not in task_handler.tasks
 
 
-def test_remove_task_from_many():
-    zeebe_task_handler.tasks.append(task)
+def test_remove_task_from_many(task_handler, task):
+    task_handler.tasks.append(task)
 
     for i in range(0, randint(0, 100)):
-        zeebe_task_handler.tasks.append(Task(str(uuid4()), lambda x: x, lambda x: x))
-    assert zeebe_task_handler.remove_task(task.type) is not None
-    assert task not in zeebe_task_handler.tasks
+        task_handler.tasks.append(Task(str(uuid4()), lambda x: x, lambda x: x))
+    assert task_handler.remove_task(task.type) is not None
+    assert task not in task_handler.tasks
 
 
-def test_remove_fake_task():
+def test_remove_fake_task(task_handler):
     with pytest.raises(TaskNotFound):
-        zeebe_task_handler.remove_task(str(uuid4()))
+        task_handler.remove_task(str(uuid4()))
 
 
-def test_add_dict_task():
-    with patch("tests.unit.worker.task_handler_test.zeebe_task_handler._dict_task") as dict_task_mock:
-        @zeebe_task_handler.task(task_type=str(uuid4()))
-        def dict_task():
-            return {}
+def test_add_dict_task(task_handler):
+    task_handler._dict_task = MagicMock()
 
-        dict_task_mock.assert_called()
+    @task_handler.task(task_type=str(uuid4()))
+    def dict_task():
+        return {}
 
-
-def test_add_non_dict_task():
-    with patch("tests.unit.worker.task_handler_test.zeebe_task_handler._non_dict_task") as non_dict_task_mock:
-        @zeebe_task_handler.task(task_type=str(uuid4()), single_value=True, variable_name=str(uuid4()))
-        def non_dict_task():
-            return True
-
-        non_dict_task_mock.assert_called()
+    task_handler._dict_task.assert_called()
 
 
-def test_add_non_dict_task_without_variable_name():
+def test_add_non_dict_task(task_handler):
+    task_handler._non_dict_task = MagicMock()
+
+    @task_handler.task(task_type=str(uuid4()), single_value=True, variable_name=str(uuid4()))
+    def non_dict_task():
+        return True
+
+    task_handler._non_dict_task.assert_called()
+
+
+def test_add_non_dict_task_without_variable_name(task_handler):
     with pytest.raises(NoVariableNameGiven):
-        @zeebe_task_handler.task(task_type=str(uuid4()), single_value=True)
+        @task_handler.task(task_type=str(uuid4()), single_value=True)
         def non_dict_task():
             return True
 
 
-def test_fn_to_dict():
+def test_fn_to_dict(task_handler):
     variable_name = str(uuid4())
 
     def no_dict_fn(x):
         return x + 1
 
-    dict_fn = zeebe_task_handler._single_value_function_to_dict(fn=no_dict_fn, variable_name=variable_name)
+    dict_fn = task_handler._single_value_function_to_dict(fn=no_dict_fn, variable_name=variable_name)
 
     variable = randint(0, 1000)
     assert dict_fn(variable) == {variable_name: variable + 1}
 
 
-def test_default_exception_handler():
+def test_default_exception_handler(job_without_adapter):
     with patch("pyzeebe.worker.task_handler.logger.warning") as logging_mock:
         with patch("pyzeebe.job.job.Job.set_failure_status") as failure_mock:
             failure_mock.return_value = None
-            job = random_job()
-            default_exception_handler(Exception(), job)
+            default_exception_handler(Exception(), job_without_adapter)
 
             failure_mock.assert_called()
         logging_mock.assert_called()
 
 
-def test_get_parameters_from_function_no_parameters():
+def test_get_parameters_from_function_no_parameters(task_handler):
     def no_parameters():
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(no_parameters) == []
+    assert task_handler._get_parameters_from_function(no_parameters) == []
 
 
-def test_get_parameters_from_function_one_positional():
+def test_get_parameters_from_function_one_positional(task_handler):
     def one_pos_func(x):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(one_pos_func) == ["x"]
+    assert task_handler._get_parameters_from_function(one_pos_func) == ["x"]
 
 
-def test_get_parameters_from_function_multiple_positional():
+def test_get_parameters_from_function_multiple_positional(task_handler):
     def mul_pos_func(x, y, z):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(mul_pos_func) == ["x", "y", "z"]
+    assert task_handler._get_parameters_from_function(mul_pos_func) == ["x", "y", "z"]
 
 
-def test_get_parameters_from_function_one_keyword():
+def test_get_parameters_from_function_one_keyword(task_handler):
     def one_key_func(x=0):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(one_key_func) == ["x"]
+    assert task_handler._get_parameters_from_function(one_key_func) == ["x"]
 
 
-def test_get_parameters_from_function_multiple_keywords():
+def test_get_parameters_from_function_multiple_keywords(task_handler):
     def mul_key_func(x=0, y=0, z=0):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(mul_key_func) == ["x", "y", "z"]
+    assert task_handler._get_parameters_from_function(mul_key_func) == ["x", "y", "z"]
 
 
-def test_get_parameters_from_function_positional_and_keyword():
+def test_get_parameters_from_function_positional_and_keyword(task_handler):
     def pos_and_key_func(x, y=0):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(pos_and_key_func) == ["x", "y"]
+    assert task_handler._get_parameters_from_function(pos_and_key_func) == ["x", "y"]
 
 
-def test_get_parameters_from_function_args():
+def test_get_parameters_from_function_args(task_handler):
     def args_func(*args):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(args_func) == []
+    assert task_handler._get_parameters_from_function(args_func) == []
 
 
-def test_get_parameters_from_function_kwargs():
+def test_get_parameters_from_function_kwargs(task_handler):
     def kwargs_func(**kwargs):
         pass
 
-    assert zeebe_task_handler._get_parameters_from_function(kwargs_func) == []
+    assert task_handler._get_parameters_from_function(kwargs_func) == []
 
 
-def test_get_parameters_from_function_lambda():
+def test_get_parameters_from_function_lambda(task_handler):
     my_func = lambda x: x
 
-    assert zeebe_task_handler._get_parameters_from_function(my_func) == ["x"]
+    assert task_handler._get_parameters_from_function(my_func) == ["x"]
 
 
-def test_check_is_task_duplicate_with_duplicate():
-    zeebe_task_handler.tasks.append(task)
+def test_check_is_task_duplicate_with_duplicate(task_handler, task):
+    task_handler.tasks.append(task)
     with pytest.raises(DuplicateTaskType):
-        zeebe_task_handler._is_task_duplicate(task.type)
+        task_handler._is_task_duplicate(task.type)
 
 
-def test_check_is_task_duplicate_no_duplicate():
-    zeebe_task_handler.tasks.append(task)
+def test_check_is_task_duplicate_no_duplicate(task_handler, task):
+    task_handler.tasks.append(task)

--- a/tests/unit/worker/task_router_test.py
+++ b/tests/unit/worker/task_router_test.py
@@ -2,43 +2,28 @@ from random import randint
 from unittest.mock import patch
 from uuid import uuid4
 
-import pytest
-
 from pyzeebe.job.job import Job
-from pyzeebe.task.task import Task
-from pyzeebe.worker.task_router import ZeebeTaskRouter
-
-zeebe_task_router: ZeebeTaskRouter
 
 
 def decorator(job: Job) -> Job:
     return job
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    global zeebe_task_router
-    zeebe_task_router = ZeebeTaskRouter()
-    yield
-    zeebe_task_router = ZeebeTaskRouter()
-
-
-def test_add_task_through_decorator():
+def test_add_task_through_decorator(router):
     task_type = str(uuid4())
     timeout = randint(0, 10000)
     max_jobs_to_activate = randint(0, 1000)
 
-    @zeebe_task_router.task(task_type=task_type, timeout=timeout, max_jobs_to_activate=max_jobs_to_activate)
+    @router.task(task_type=task_type, timeout=timeout, max_jobs_to_activate=max_jobs_to_activate)
     def example_test_task(x):
         return {"x": x}
 
-    assert len(zeebe_task_router.tasks) == 1
+    assert len(router.tasks) == 1
 
     variable = str(uuid4())
     assert example_test_task(variable) == {"x": variable}
 
-    global task
-    task = zeebe_task_router.get_task(task_type)
+    task = router.get_task(task_type)
     assert task is not None
 
     variable = str(uuid4())
@@ -48,96 +33,94 @@ def test_add_task_through_decorator():
     assert task.max_jobs_to_activate == max_jobs_to_activate
 
 
-def test_router_before_decorator():
+def test_router_before_decorator(router):
     task_type = str(uuid4())
-    zeebe_task_router.before(decorator)
+    router.before(decorator)
 
-    @zeebe_task_router.task(task_type=task_type)
+    @router.task(task_type=task_type)
     def task_fn(x):
         return {"x": x}
 
-    task = zeebe_task_router.get_task(task_type)
+    task = router.get_task(task_type)
     assert task is not None
     assert len(task._before) == 1
     assert len(task._after) == 0
 
 
-def test_router_after_before_multiple():
+def test_router_after_before_multiple(router):
     task_type = str(uuid4())
-    zeebe_task_router.before(decorator)
+    router.before(decorator)
 
-    @zeebe_task_router.task(task_type=task_type, before=[decorator])
+    @router.task(task_type=task_type, before=[decorator])
     def task_fn(x):
         return {"x": x}
 
-    task = zeebe_task_router.get_task(task_type)
+    task = router.get_task(task_type)
     assert task is not None
     assert len(task._before) == 2
     assert len(task._after) == 0
 
 
-def test_router_after_decorator():
+def test_router_after_decorator(router):
     task_type = str(uuid4())
-    zeebe_task_router.after(decorator)
+    router.after(decorator)
 
-    @zeebe_task_router.task(task_type=task_type)
+    @router.task(task_type=task_type)
     def task_fn(x):
         return {"x": x}
 
-    task = zeebe_task_router.get_task(task_type)
+    task = router.get_task(task_type)
     assert task is not None
     assert len(task._after) == 1
     assert len(task._before) == 0
 
 
-def test_router_after_decorator_multiple():
+def test_router_after_decorator_multiple(router):
     task_type = str(uuid4())
-    zeebe_task_router.after(decorator)
+    router.after(decorator)
 
-    @zeebe_task_router.task(task_type=task_type, after=[decorator])
+    @router.task(task_type=task_type, after=[decorator])
     def task_fn(x):
         return {"x": x}
 
-    task = zeebe_task_router.get_task(task_type)
+    task = router.get_task(task_type)
     assert task is not None
     assert len(task._after) == 2
     assert len(task._before) == 0
 
 
-def test_router_non_dict_task():
+def test_router_non_dict_task(router):
     with patch("pyzeebe.worker.task_handler.ZeebeTaskHandler._single_value_function_to_dict") as single_value_mock:
         task_type = str(uuid4())
         variable_name = str(uuid4())
 
-        @zeebe_task_router.task(task_type=task_type, single_value=True, variable_name=variable_name)
+        @router.task(task_type=task_type, single_value=True, variable_name=variable_name)
         def task_fn(x):
             return {"x": x}
 
         single_value_mock.assert_called_with(variable_name=variable_name, fn=task_fn)
-    assert len(zeebe_task_router.tasks) == 1
+    assert len(router.tasks) == 1
 
 
-def test_router_dict_task():
+def test_router_dict_task(router):
     task_type = str(uuid4())
 
-    @zeebe_task_router.task(task_type=task_type)
+    @router.task(task_type=task_type)
     def task_fn(x):
         return {"x": x}
 
-    assert len(zeebe_task_router.tasks) == 1
+    assert len(router.tasks) == 1
 
 
-def test_add_decorators_to_task():
-    task = Task(task_handler=lambda x: x, exception_handler=lambda x: x, task_type=str(uuid4()))
-    zeebe_task_router._add_decorators_to_task(task, [decorator], [decorator])
+def test_add_decorators_to_task(router, task):
+    router._add_decorators_to_task(task, [decorator], [decorator])
     assert len(task._before) == 1
     assert len(task._after) == 1
 
 
-def test_add_decorators_to_task_with_router_decorators():
-    task = Task(task_handler=lambda x: x, exception_handler=lambda x: x, task_type=str(uuid4()))
-    zeebe_task_router.before(decorator)
-    zeebe_task_router.after(decorator)
-    zeebe_task_router._add_decorators_to_task(task, [decorator], [decorator])
+def test_add_decorators_to_task_with_router_decorators(router, task):
+    router.before(decorator)
+    router.after(decorator)
+    router._add_decorators_to_task(task, [decorator], [decorator])
     assert len(task._before) == 2
     assert len(task._after) == 2

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -60,22 +60,6 @@ def test_add_task_through_decorator(zeebe_worker):
         mock.assert_called_with(job_key=job.key, variables=job.variables)
 
 
-def test_add_task(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-    assert len(zeebe_worker.tasks) == 1
-    assert zeebe_worker.get_task(task.type).handler is not None
-
-    variable = str(uuid4())
-    assert task.inner_function(variable) == {"x": variable}
-
-    assert callable(task.handler)
-    job = random_job(task=task)
-    job.variables = {"x": str(uuid4())}
-    with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.complete_job") as mock:
-        assert isinstance(task.handler(job), Job)
-        mock.assert_called_with(job_key=job.key, variables=job.variables)
-
-
 def test_before_task_decorator_called(zeebe_worker, task):
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         job = random_job(task=task)

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -3,12 +3,13 @@ from threading import Thread
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
+import pytest
+
 from pyzeebe.exceptions import DuplicateTaskType
 from pyzeebe.job.job import Job
 from pyzeebe.task.task import Task
 from pyzeebe.worker.task_router import ZeebeTaskRouter
 from pyzeebe.worker.worker import ZeebeWorker
-from tests.unit.utils.grpc_utils import *
 from tests.unit.utils.random_utils import random_job
 
 zeebe_worker: ZeebeWorker

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -176,8 +176,7 @@ def test_handle_one_job(zeebe_worker, task):
 
     with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
         get_jobs_mock.return_value = [job]
-        task.handler = MagicMock()
-        task.handler.return_value = {"x": str(uuid4())}
+        task.handler = MagicMock(return_value={"x": str(uuid4())})
         zeebe_worker._handle_jobs(task)
         task.handler.assert_called_with(job)
 
@@ -185,13 +184,12 @@ def test_handle_one_job(zeebe_worker, task):
 def test_handle_no_job(zeebe_worker, task):
     job = random_job(task=task)
 
-    with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
-        get_jobs_mock.return_value = []
-        task.handler = MagicMock()
-        task.handler.return_value = {"x": str(uuid4())}
-        zeebe_worker._handle_jobs(task)
-        with pytest.raises(AssertionError):
-            task.handler.assert_called_with(job)
+    zeebe_worker._get_jobs = MagicMock(return_value=[])
+    task.handler = MagicMock(return_value={"x": str(uuid4())})
+    zeebe_worker._handle_jobs(task)
+
+    with pytest.raises(AssertionError):
+        task.handler.assert_called_with(job)
 
 
 def test_handle_many_jobs(zeebe_worker, task):
@@ -199,8 +197,7 @@ def test_handle_many_jobs(zeebe_worker, task):
 
     with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
         get_jobs_mock.return_value = [job]
-        task.handler = MagicMock()
-        task.handler.return_value = {"x": str(uuid4())}
+        task.handler = MagicMock(return_value={"x": str(uuid4())})
         zeebe_worker._handle_jobs(task)
         task.handler.assert_called_with(job)
 

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -7,43 +7,28 @@ import pytest
 
 from pyzeebe.exceptions import DuplicateTaskType
 from pyzeebe.job.job import Job
-from pyzeebe.task.task import Task
-from pyzeebe.worker.task_router import ZeebeTaskRouter
 from pyzeebe.worker.worker import ZeebeWorker
 from tests.unit.utils.random_utils import random_job
-
-zeebe_worker: ZeebeWorker
-task: Task
 
 
 def decorator(job: Job) -> Job:
     return job
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    global zeebe_worker, task
-    task = Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
-    zeebe_worker = ZeebeWorker()
-    yield
-    zeebe_worker = ZeebeWorker()
-    task = Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
-
-
-def test_add_task():
+def test_add_task(zeebe_worker, task):
     zeebe_worker._add_task(task)
 
     assert len(zeebe_worker.tasks) == 1
     assert zeebe_worker.get_task(task.type) == task
 
 
-def test_add_duplicate_task():
+def test_add_duplicate_task(zeebe_worker, task):
     zeebe_worker._add_task(task)
     with pytest.raises(DuplicateTaskType):
         zeebe_worker._add_task(task)
 
 
-def test_add_task_through_decorator():
+def test_add_task_through_decorator(zeebe_worker):
     task_type = str(uuid4())
     timeout = randint(0, 10000)
     max_jobs_to_activate = randint(0, 1000)
@@ -58,7 +43,6 @@ def test_add_task_through_decorator():
     variable = str(uuid4())
     assert example_test_task(variable) == {"x": variable}
 
-    global task
     task = zeebe_worker.get_task(task_type)
     assert task is not None
 
@@ -76,7 +60,7 @@ def test_add_task_through_decorator():
         mock.assert_called_with(job_key=job.key, variables=job.variables)
 
 
-def test_add_task():
+def test_add_task(zeebe_worker, task):
     zeebe_worker._add_task(task)
     assert len(zeebe_worker.tasks) == 1
     assert zeebe_worker.get_task(task.type).handler is not None
@@ -92,7 +76,7 @@ def test_add_task():
         mock.assert_called_with(job_key=job.key, variables=job.variables)
 
 
-def test_before_task_decorator_called():
+def test_before_task_decorator_called(zeebe_worker, task):
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         job = random_job(task=task)
         job.variables = {"x": str(uuid4())}
@@ -107,7 +91,7 @@ def test_before_task_decorator_called():
         mock.assert_called_with(job)
 
 
-def test_after_task_decorator_called():
+def test_after_task_decorator_called(zeebe_worker, task):
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         job = random_job(task=task)
         job.variables = {"x": str(uuid4())}
@@ -123,7 +107,7 @@ def test_after_task_decorator_called():
         mock.assert_called_with(job)
 
 
-def test_decorator_failed():
+def test_decorator_failed(zeebe_worker, task):
     job = random_job(task=task)
 
     with patch("tests.unit.worker.worker_test.decorator") as decorator_mock:
@@ -136,7 +120,7 @@ def test_decorator_failed():
         assert decorator_mock.call_count == 2
 
 
-def test_task_exception_handler_called():
+def test_task_exception_handler_called(zeebe_worker, task):
     def task_handler(x):
         raise Exception()
 
@@ -149,19 +133,19 @@ def test_task_exception_handler_called():
     task.inner_function = task_handler
     task.exception_handler = exception_handler
 
-    with patch("tests.unit.worker.worker_test.task.exception_handler") as mock:
-        zeebe_worker._add_task(task)
-        task.handler(job)
-        mock.assert_called()
+    task.exception_handler = MagicMock()
+    zeebe_worker._add_task(task)
+    task.handler(job)
+    task.exception_handler.assert_called()
 
 
-def test_add_before_decorator():
+def test_add_before_decorator(zeebe_worker):
     zeebe_worker.before(decorator)
     assert len(zeebe_worker._before) == 1
     assert decorator in zeebe_worker._before
 
 
-def test_add_after_decorator():
+def test_add_after_decorator(zeebe_worker):
     zeebe_worker.after(decorator)
     assert len(zeebe_worker._after) == 1
     assert decorator in zeebe_worker._after
@@ -179,7 +163,7 @@ def test_add_constructor_after_decorator():
     assert decorator in zeebe_worker._after
 
 
-def test_create_before_decorator_runner():
+def test_create_before_decorator_runner(zeebe_worker, task):
     task.before(decorator)
     job = random_job(task=task)
     job.variables = {"x": str(uuid4())}
@@ -187,41 +171,41 @@ def test_create_before_decorator_runner():
     assert isinstance(decorators(job), Job)
 
 
-def test_handle_one_job():
+def test_handle_one_job(zeebe_worker, task):
     job = random_job(task=task)
 
     with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
         get_jobs_mock.return_value = [job]
-        with patch("tests.unit.worker.worker_test.task.handler") as task_handler_mock:
-            task_handler_mock.return_value = {"x": str(uuid4())}
-            zeebe_worker._handle_jobs(task)
-            task_handler_mock.assert_called_with(job)
+        task.handler = MagicMock()
+        task.handler.return_value = {"x": str(uuid4())}
+        zeebe_worker._handle_jobs(task)
+        task.handler.assert_called_with(job)
 
 
-def test_handle_no_job():
+def test_handle_no_job(zeebe_worker, task):
     job = random_job(task=task)
 
     with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
         get_jobs_mock.return_value = []
-        with patch("tests.unit.worker.worker_test.task.handler") as task_handler_mock:
-            task_handler_mock.return_value = {"x": str(uuid4())}
-            zeebe_worker._handle_jobs(task)
-            with pytest.raises(AssertionError):
-                task_handler_mock.assert_called_with(job)
+        task.handler = MagicMock()
+        task.handler.return_value = {"x": str(uuid4())}
+        zeebe_worker._handle_jobs(task)
+        with pytest.raises(AssertionError):
+            task.handler.assert_called_with(job)
 
 
-def test_handle_many_jobs():
+def test_handle_many_jobs(zeebe_worker, task):
     job = random_job(task=task)
 
     with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
         get_jobs_mock.return_value = [job]
-        with patch("tests.unit.worker.worker_test.task.handler") as task_handler_mock:
-            task_handler_mock.return_value = {"x": str(uuid4())}
-            zeebe_worker._handle_jobs(task)
-            task_handler_mock.assert_called_with(job)
+        task.handler = MagicMock()
+        task.handler.return_value = {"x": str(uuid4())}
+        zeebe_worker._handle_jobs(task)
+        task.handler.assert_called_with(job)
 
 
-def test_work_thread_start_called():
+def test_work_thread_start_called(zeebe_worker, task):
     Thread.start = MagicMock()
     zeebe_worker._add_task(task)
     zeebe_worker.work()
@@ -229,14 +213,13 @@ def test_work_thread_start_called():
     Thread.start.assert_called_once()
 
 
-def test_stop_worker():
+def test_stop_worker(zeebe_worker):
     zeebe_worker.work()
     zeebe_worker.stop()
 
 
-def test_include_router():
+def test_include_router(zeebe_worker, router):
     task_type = str(uuid4())
-    router = ZeebeTaskRouter()
 
     @router.task(task_type=task_type)
     def task_fn(x):
@@ -246,9 +229,7 @@ def test_include_router():
     assert zeebe_worker.get_task(task_type) is not None
 
 
-def test_include_multiple_routers():
-    routers = [ZeebeTaskRouter() for _ in range(0, randint(2, 100))]
-
+def test_include_multiple_routers(zeebe_worker, routers):
     for router in routers:
         task_type = str(uuid4())
 
@@ -261,10 +242,9 @@ def test_include_multiple_routers():
     assert len(zeebe_worker.tasks) == len(routers)
 
 
-def test_router_before_decorator():
+def test_router_before_decorator(zeebe_worker, router):
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         task_type = str(uuid4())
-        router = ZeebeTaskRouter()
         router.before(decorator)
 
         @router.task(task_type=task_type, before=[decorator])
@@ -288,10 +268,9 @@ def test_router_before_decorator():
         assert mock.call_count == 3
 
 
-def test_router_after_decorator():
+def test_router_after_decorator(zeebe_worker, router):
     with patch("tests.unit.worker.worker_test.decorator") as mock:
         task_type = str(uuid4())
-        router = ZeebeTaskRouter()
         router.after(decorator)
 
         @router.task(task_type=task_type, after=[decorator])
@@ -315,7 +294,7 @@ def test_router_after_decorator():
         assert mock.call_count == 3
 
 
-def test_router_non_dict_task():
+def test_router_non_dict_task(zeebe_worker):
     with patch("pyzeebe.worker.task_handler.ZeebeTaskHandler._single_value_function_to_dict") as single_value_mock:
         task_type = str(uuid4())
         variable_name = str(uuid4())
@@ -328,7 +307,7 @@ def test_router_non_dict_task():
     assert len(zeebe_worker.tasks) == 1
 
 
-def test_get_jobs():
+def test_get_jobs(zeebe_worker, task):
     zeebe_worker.zeebe_adapter.activate_jobs = MagicMock()
     zeebe_worker._get_jobs(task)
     zeebe_worker.zeebe_adapter.activate_jobs.assert_called_with(task_type=task.type, worker=zeebe_worker.name,


### PR DESCRIPTION
Use [pytest fixtures](https://docs.pytest.org/en/stable/fixture.html) to increase test maintainability.

## Changes

- Move all fixtures to `conftest.py`.
- Change all tests to use fixtures instead of global variables
- Use [pytest-grpc](https://pypi.org/project/pytest-grpc/) as intended, which fixes #115 

## API Updates

### New Features *(required)*
none

## Checklist

- [x] Unit tests
- [ ] Documentation
