### PR TITLE
Refactor worker tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def zeebe_worker(zeebe_adapter):
 
 @pytest.fixture
 def task():
-    return Task(str(uuid4()), lambda x: {"x": x}, lambda x, y, z: x)
+    return Task(str(uuid4()), MagicMock(wraps=lambda x: {"x": x}), MagicMock(wraps=lambda x, y, z: x))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,13 @@ def zeebe_worker(zeebe_adapter):
 
 
 @pytest.fixture
-def task():
-    return Task(str(uuid4()), MagicMock(wraps=lambda x: {"x": x}), MagicMock(wraps=lambda x, y, z: x))
+def task(task_type):
+    return Task(task_type, MagicMock(wraps=lambda x: {"x": x}), MagicMock(wraps=lambda x, y, z: x))
+
+
+@pytest.fixture
+def task_type():
+    return str(uuid4())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,11 @@ def job_without_adapter():
 
 
 @pytest.fixture
+def job_from_task(task):
+    return random_job(task)
+
+
+@pytest.fixture
 def zeebe_adapter(grpc_create_channel):
     return ZeebeAdapter(channel=grpc_create_channel())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 from random import randint
 from threading import Event
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from uuid import uuid4
 
 import pytest
 
-from pyzeebe import ZeebeClient, ZeebeWorker, ZeebeTaskRouter
+from pyzeebe import ZeebeClient, ZeebeWorker, ZeebeTaskRouter, Job
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 from pyzeebe.task.task import Task
 from pyzeebe.worker.task_handler import ZeebeTaskHandler
@@ -83,6 +83,14 @@ def routers():
 @pytest.fixture
 def task_handler():
     return ZeebeTaskHandler()
+
+
+@pytest.fixture
+def decorator():
+    def simple_decorator(job: Job) -> Job:
+        return job
+
+    return MagicMock(wraps=simple_decorator)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,9 @@ def job_without_adapter():
 
 @pytest.fixture
 def job_from_task(task):
-    return random_job(task)
+    job = random_job(task)
+    job.variables = dict(x=str(uuid4()))
+    return job
 
 
 @pytest.fixture
@@ -47,7 +49,7 @@ def zeebe_worker(zeebe_adapter):
 
 @pytest.fixture
 def task(task_type):
-    return Task(task_type, MagicMock(wraps=lambda x: {"x": x}), MagicMock(wraps=lambda x, y, z: x))
+    return Task(task_type, MagicMock(wraps=lambda x: dict(x=x)), MagicMock(wraps=lambda x, y, z: x))
 
 
 @pytest.fixture

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -8,7 +8,6 @@ import pytest
 from pyzeebe.exceptions import DuplicateTaskType, MaxConsecutiveTaskThreadError
 from pyzeebe.job.job import Job
 from pyzeebe.worker.worker import ZeebeWorker
-from tests.unit.utils.random_utils import random_job
 
 
 class TestAddTask:
@@ -36,14 +35,12 @@ class TestAddTask:
 
     def test_original_function_not_changed(self, zeebe_worker, task, job_from_task):
         zeebe_worker._add_task(task)
-        job_from_task.variables = {"x": str(uuid4())}
 
         assert task.inner_function(**job_from_task.variables) == job_from_task.variables
 
     def test_task_handler_calls_original_function(self, zeebe_worker, task, job_from_task):
-        job_from_task.variables = {"x": str(uuid4())}
-
         zeebe_worker._add_task(task)
+
         task.handler(job_from_task)
 
         task.inner_function.assert_called_once()
@@ -79,7 +76,6 @@ class TestAddTask:
         assert callable(task.handler)
 
     def test_exception_handler_called(self, zeebe_worker, task, job_from_task):
-        job_from_task.variables = {"x": str(uuid4())}
         task.inner_function.side_effect = Exception()
         task.exception_handler = MagicMock()
         zeebe_worker._add_task(task)
@@ -112,13 +108,12 @@ class TestDecorator:
 
     def test_create_before_decorator_runner(self, zeebe_worker, task, decorator, job_from_task):
         task.before(decorator)
-        job_from_task.variables = {"x": str(uuid4())}
+
         decorators = zeebe_worker._create_before_decorator_runner(task)
+
         assert isinstance(decorators(job_from_task), Job)
 
     def test_before_task_decorator_called(self, zeebe_worker, task, decorator, job_from_task):
-        job_from_task.variables = {"x": str(uuid4())}
-
         task.before(decorator)
         zeebe_worker._add_task(task)
 
@@ -127,8 +122,6 @@ class TestDecorator:
         decorator.assert_called_with(job_from_task)
 
     def test_after_task_decorator_called(self, zeebe_worker, task, decorator, job_from_task):
-        job_from_task.variables = {"x": str(uuid4())}
-
         task.after(decorator)
         zeebe_worker._add_task(task)
 
@@ -207,6 +200,7 @@ class TestGetJobs:
 class TestIncludeRouter:
     def test_include_router_adds_task(self, zeebe_worker, router, task_type):
         self.include_router_with_task(zeebe_worker, router, task_type)
+
         assert zeebe_worker.get_task(task_type) is not None
 
     def test_include_multiple_routers(self, zeebe_worker, routers):

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -73,8 +73,7 @@ def test_task_max_jobs_saved(zeebe_worker, task):
     assert zeebe_worker.get_task(task.type).max_jobs_to_activate == max_jobs_to_activate
 
 
-def test_task_variables_to_fetch_are_correct(zeebe_worker):
-    task_type = str(uuid4())
+def test_task_variables_to_fetch_are_correct(zeebe_worker, task_type):
     expected_variables_to_fetch = ["x"]
 
     @zeebe_worker.task(task_type)
@@ -216,9 +215,7 @@ def test_stop_worker(zeebe_worker):
     zeebe_worker.stop()
 
 
-def test_include_router(zeebe_worker, router):
-    task_type = str(uuid4())
-
+def test_include_router(zeebe_worker, router, task_type):
     @router.task(task_type=task_type)
     def task_fn(x):
         return {"x": x}
@@ -227,11 +224,9 @@ def test_include_router(zeebe_worker, router):
     assert zeebe_worker.get_task(task_type) is not None
 
 
-def test_include_multiple_routers(zeebe_worker, routers):
+def test_include_multiple_routers(zeebe_worker, routers, task_type):
     for router in routers:
-        task_type = str(uuid4())
-
-        @router.task(task_type=task_type)
+        @router.task(str(uuid4()))
         def task_fn(x):
             return {"x": x}
 
@@ -240,8 +235,7 @@ def test_include_multiple_routers(zeebe_worker, routers):
     assert len(zeebe_worker.tasks) == len(routers)
 
 
-def test_router_before_decorator(zeebe_worker, router, decorator):
-    task_type = str(uuid4())
+def test_router_before_decorator(zeebe_worker, router, decorator, task_type):
     router.before(decorator)
 
     @router.task(task_type=task_type, before=[decorator])
@@ -265,8 +259,7 @@ def test_router_before_decorator(zeebe_worker, router, decorator):
     assert decorator.call_count == 3
 
 
-def test_router_after_decorator(zeebe_worker, router, decorator):
-    task_type = str(uuid4())
+def test_router_after_decorator(zeebe_worker, router, decorator, task_type):
     router.after(decorator)
 
     @router.task(task_type=task_type, after=[decorator])
@@ -290,9 +283,8 @@ def test_router_after_decorator(zeebe_worker, router, decorator):
     assert decorator.call_count == 3
 
 
-def test_router_non_dict_task(zeebe_worker):
+def test_router_non_dict_task(zeebe_worker, task_type):
     with patch("pyzeebe.worker.task_handler.ZeebeTaskHandler._single_value_function_to_dict") as single_value_mock:
-        task_type = str(uuid4())
         variable_name = str(uuid4())
 
         @zeebe_worker.task(task_type=task_type, single_value=True, variable_name=variable_name)

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -187,7 +187,7 @@ class TestStartAndStop:
 
 
 class TestGetJobs:
-    def test_get_jobs(self, zeebe_worker, task):
+    def test_activate_jobs_called(self, zeebe_worker, task):
         zeebe_worker.zeebe_adapter.activate_jobs = MagicMock()
         zeebe_worker._get_jobs(task)
         zeebe_worker.zeebe_adapter.activate_jobs.assert_called_with(task_type=task.type, worker=zeebe_worker.name,

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -147,7 +147,7 @@ class TestHandleJobs:
 
     @pytest.fixture(autouse=True)
     def task_handler_mock(self, task):
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
+        task.handler = MagicMock(wraps=task.handler)
 
     def test_handle_no_job(self, zeebe_worker, task, get_jobs_mock):
         get_jobs_mock.return_value = []

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -152,9 +152,12 @@ class TestHandleJobs:
         zeebe_worker._get_jobs = MagicMock()
         return zeebe_worker._get_jobs
 
+    @pytest.fixture(autouse=True)
+    def task_handler_mock(self, task):
+        task.handler = MagicMock(return_value={"x": str(uuid4())})
+
     def test_handle_no_job(self, zeebe_worker, task, get_jobs_mock):
         get_jobs_mock.return_value = []
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
 
         zeebe_worker._handle_jobs(task)
 
@@ -162,7 +165,6 @@ class TestHandleJobs:
 
     def test_handle_one_job(self, zeebe_worker, task, job_from_task, get_jobs_mock):
         get_jobs_mock.return_value = [job_from_task]
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
 
         zeebe_worker._handle_jobs(task)
 
@@ -170,7 +172,6 @@ class TestHandleJobs:
 
     def test_handle_many_jobs(self, zeebe_worker, task, job_from_task, get_jobs_mock):
         get_jobs_mock.return_value = [job_from_task] * 10
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
 
         zeebe_worker._handle_jobs(task)
 

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -93,21 +93,14 @@ def test_decorator_failed(zeebe_worker, task, decorator):
 
 
 def test_task_exception_handler_called(zeebe_worker, task):
-    def task_handler(x):
-        raise Exception()
-
-    def exception_handler(e, job, status_setter):
-        pass
-
     job = random_job(task=task)
     job.variables = {"x": str(uuid4())}
-
-    task.inner_function = task_handler
-    task.exception_handler = exception_handler
-
+    task.inner_function.side_effect = Exception()
     task.exception_handler = MagicMock()
     zeebe_worker._add_task(task)
+
     task.handler(job)
+
     task.exception_handler.assert_called()
 
 

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -11,280 +11,243 @@ from pyzeebe.worker.worker import ZeebeWorker
 from tests.unit.utils.random_utils import random_job
 
 
-def test_add_task_saves_task(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-
-    assert zeebe_worker.get_task(task.type) == task
-
-
-def test_add_duplicate_task(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-    with pytest.raises(DuplicateTaskType):
+class TestAddTask:
+    def test_task_added(self, zeebe_worker, task):
         zeebe_worker._add_task(task)
 
+        assert zeebe_worker.get_task(task.type) == task
 
-def test_only_one_task_added(zeebe_worker):
-    @zeebe_worker.task(str(uuid4()))
-    def _():
-        pass
-
-    assert len(zeebe_worker.tasks) == 1
-
-
-def test_task_type_saved(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-
-    assert zeebe_worker.get_task(task.type).type == task.type
-
-
-def test_original_function_not_changed(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-    job = random_job(task)
-    job.variables = {"x": str(uuid4())}
-
-    assert task.inner_function(**job.variables) == job.variables
-
-
-def test_task_handler_calls_original_function(zeebe_worker, task):
-    job = random_job(task)
-    job.variables = {"x": str(uuid4())}
-
-    zeebe_worker._add_task(task)
-    task.handler(job)
-
-    task.inner_function.assert_called_once()
-
-
-def test_task_timeout_saved(zeebe_worker, task):
-    timeout = randint(0, 10000)
-    task.timeout = timeout
-
-    zeebe_worker._add_task(task)
-
-    assert zeebe_worker.get_task(task.type).timeout == timeout
-
-
-def test_task_max_jobs_saved(zeebe_worker, task):
-    max_jobs_to_activate = randint(0, 1000)
-    task.max_jobs_to_activate = max_jobs_to_activate
-
-    zeebe_worker._add_task(task)
-
-    assert zeebe_worker.get_task(task.type).max_jobs_to_activate == max_jobs_to_activate
-
-
-def test_task_variables_to_fetch_are_correct(zeebe_worker, task_type):
-    expected_variables_to_fetch = ["x"]
-
-    @zeebe_worker.task(task_type)
-    def _(x):
-        pass
-
-    assert zeebe_worker.get_task(task_type).variables_to_fetch == expected_variables_to_fetch
-
-
-def test_task_handler_is_callable(zeebe_worker, task):
-    zeebe_worker._add_task(task)
-
-    assert callable(task.handler)
-
-
-def test_before_task_decorator_called(zeebe_worker, task, decorator):
-    job = random_job(task=task)
-    job.variables = {"x": str(uuid4())}
-
-    task.before(decorator)
-    zeebe_worker._add_task(task)
-
-    task.handler(job)
-
-    decorator.assert_called_with(job)
-
-
-def test_after_task_decorator_called(zeebe_worker, task, decorator):
-    job = random_job(task=task)
-    job.variables = {"x": str(uuid4())}
-
-    task.after(decorator)
-    zeebe_worker._add_task(task)
-
-    task.handler(job)
-
-    decorator.assert_called_with(job)
-
-
-def test_decorator_failed(zeebe_worker, task, decorator):
-    job = random_job(task=task)
-
-    decorator.side_effect = Exception()
-    zeebe_worker.before(decorator)
-    zeebe_worker.after(decorator)
-    zeebe_worker._add_task(task)
-
-    assert isinstance(task.handler(job), Job)
-    assert decorator.call_count == 2
-
-
-def test_task_exception_handler_called(zeebe_worker, task):
-    job = random_job(task=task)
-    job.variables = {"x": str(uuid4())}
-    task.inner_function.side_effect = Exception()
-    task.exception_handler = MagicMock()
-    zeebe_worker._add_task(task)
-
-    task.handler(job)
-
-    task.exception_handler.assert_called()
-
-
-def test_add_before_decorator(zeebe_worker, decorator):
-    zeebe_worker.before(decorator)
-    assert len(zeebe_worker._before) == 1
-    assert decorator in zeebe_worker._before
-
-
-def test_add_after_decorator(zeebe_worker, decorator):
-    zeebe_worker.after(decorator)
-    assert len(zeebe_worker._after) == 1
-    assert decorator in zeebe_worker._after
-
-
-def test_add_constructor_before_decorator(decorator):
-    zeebe_worker = ZeebeWorker(before=[decorator])
-    assert len(zeebe_worker._before) == 1
-    assert decorator in zeebe_worker._before
-
-
-def test_add_constructor_after_decorator(decorator):
-    zeebe_worker = ZeebeWorker(after=[decorator])
-    assert len(zeebe_worker._after) == 1
-    assert decorator in zeebe_worker._after
-
-
-def test_create_before_decorator_runner(zeebe_worker, task, decorator):
-    task.before(decorator)
-    job = random_job(task=task)
-    job.variables = {"x": str(uuid4())}
-    decorators = zeebe_worker._create_before_decorator_runner(task)
-    assert isinstance(decorators(job), Job)
-
-
-def test_handle_one_job(zeebe_worker, task):
-    job = random_job(task=task)
-
-    with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
-        get_jobs_mock.return_value = [job]
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
-        zeebe_worker._handle_jobs(task)
-        task.handler.assert_called_with(job)
-
-
-def test_handle_no_job(zeebe_worker, task):
-    job = random_job(task=task)
-
-    zeebe_worker._get_jobs = MagicMock(return_value=[])
-    task.handler = MagicMock(return_value={"x": str(uuid4())})
-    zeebe_worker._handle_jobs(task)
-
-    with pytest.raises(AssertionError):
-        task.handler.assert_called_with(job)
-
-
-def test_handle_many_jobs(zeebe_worker, task):
-    job = random_job(task=task)
-
-    with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
-        get_jobs_mock.return_value = [job]
-        task.handler = MagicMock(return_value={"x": str(uuid4())})
-        zeebe_worker._handle_jobs(task)
-        task.handler.assert_called_with(job)
-
-
-def test_work_thread_start_called(zeebe_worker, task):
-    with patch("pyzeebe.worker.worker.Thread") as thread_mock:
-        thread_instance_mock = MagicMock()
-        thread_mock.return_value = thread_instance_mock
+    def test_raises_on_duplicate(self, zeebe_worker, task):
         zeebe_worker._add_task(task)
+        with pytest.raises(DuplicateTaskType):
+            zeebe_worker._add_task(task)
+
+    def test_only_one_task_added(self, zeebe_worker):
+        @zeebe_worker.task(str(uuid4()))
+        def _():
+            pass
+
+        assert len(zeebe_worker.tasks) == 1
+
+    def test_task_type_saved(self, zeebe_worker, task):
+        zeebe_worker._add_task(task)
+
+        assert zeebe_worker.get_task(task.type).type == task.type
+
+    def test_original_function_not_changed(self, zeebe_worker, task):
+        zeebe_worker._add_task(task)
+        job = random_job(task)
+        job.variables = {"x": str(uuid4())}
+
+        assert task.inner_function(**job.variables) == job.variables
+
+    def test_task_handler_calls_original_function(self, zeebe_worker, task):
+        job = random_job(task)
+        job.variables = {"x": str(uuid4())}
+
+        zeebe_worker._add_task(task)
+        task.handler(job)
+
+        task.inner_function.assert_called_once()
+
+    def test_task_timeout_saved(self, zeebe_worker, task):
+        timeout = randint(0, 10000)
+        task.timeout = timeout
+
+        zeebe_worker._add_task(task)
+
+        assert zeebe_worker.get_task(task.type).timeout == timeout
+
+    def test_task_max_jobs_saved(self, zeebe_worker, task):
+        max_jobs_to_activate = randint(0, 1000)
+        task.max_jobs_to_activate = max_jobs_to_activate
+
+        zeebe_worker._add_task(task)
+
+        assert zeebe_worker.get_task(task.type).max_jobs_to_activate == max_jobs_to_activate
+
+    def test_variables_to_fetch_match_function_parameters(self, zeebe_worker, task_type):
+        expected_variables_to_fetch = ["x"]
+
+        @zeebe_worker.task(task_type)
+        def _(x):
+            pass
+
+        assert zeebe_worker.get_task(task_type).variables_to_fetch == expected_variables_to_fetch
+
+    def test_task_handler_is_callable(self, zeebe_worker, task):
+        zeebe_worker._add_task(task)
+
+        assert callable(task.handler)
+
+    def test_exception_handler_called(self, zeebe_worker, task):
+        job = random_job(task=task)
+        job.variables = {"x": str(uuid4())}
+        task.inner_function.side_effect = Exception()
+        task.exception_handler = MagicMock()
+        zeebe_worker._add_task(task)
+
+        task.handler(job)
+
+        task.exception_handler.assert_called()
+
+
+class TestDecorator:
+    def test_add_before_decorator(self, zeebe_worker, decorator):
+        zeebe_worker.before(decorator)
+        assert len(zeebe_worker._before) == 1
+        assert decorator in zeebe_worker._before
+
+    def test_add_after_decorator(self, zeebe_worker, decorator):
+        zeebe_worker.after(decorator)
+        assert len(zeebe_worker._after) == 1
+        assert decorator in zeebe_worker._after
+
+    def test_add_constructor_before_decorator(self, decorator):
+        zeebe_worker = ZeebeWorker(before=[decorator])
+        assert len(zeebe_worker._before) == 1
+        assert decorator in zeebe_worker._before
+
+    def test_add_constructor_after_decorator(self, decorator):
+        zeebe_worker = ZeebeWorker(after=[decorator])
+        assert len(zeebe_worker._after) == 1
+        assert decorator in zeebe_worker._after
+
+    def test_create_before_decorator_runner(self, zeebe_worker, task, decorator):
+        task.before(decorator)
+        job = random_job(task=task)
+        job.variables = {"x": str(uuid4())}
+        decorators = zeebe_worker._create_before_decorator_runner(task)
+        assert isinstance(decorators(job), Job)
+
+    def test_before_task_decorator_called(self, zeebe_worker, task, decorator):
+        job = random_job(task=task)
+        job.variables = {"x": str(uuid4())}
+
+        task.before(decorator)
+        zeebe_worker._add_task(task)
+
+        task.handler(job)
+
+        decorator.assert_called_with(job)
+
+    def test_after_task_decorator_called(self, zeebe_worker, task, decorator):
+        job = random_job(task=task)
+        job.variables = {"x": str(uuid4())}
+
+        task.after(decorator)
+        zeebe_worker._add_task(task)
+
+        task.handler(job)
+
+        decorator.assert_called_with(job)
+
+    def test_decorator_failed(self, zeebe_worker, task, decorator):
+        job = random_job(task=task)
+
+        decorator.side_effect = Exception()
+        zeebe_worker.before(decorator)
+        zeebe_worker.after(decorator)
+        zeebe_worker._add_task(task)
+
+        assert isinstance(task.handler(job), Job)
+        assert decorator.call_count == 2
+
+
+class TestHandleJobs:
+    def test_handle_no_job(self, zeebe_worker, task):
+        job = random_job(task=task)
+
+        zeebe_worker._get_jobs = MagicMock(return_value=[])
+        task.handler = MagicMock(return_value={"x": str(uuid4())})
+        zeebe_worker._handle_jobs(task)
+
+        with pytest.raises(AssertionError):
+            task.handler.assert_called_with(job)
+
+    def test_handle_one_job(self, zeebe_worker, task):
+        job = random_job(task=task)
+
+        with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
+            get_jobs_mock.return_value = [job]
+            task.handler = MagicMock(return_value={"x": str(uuid4())})
+            zeebe_worker._handle_jobs(task)
+            task.handler.assert_called_with(job)
+
+    def test_handle_many_jobs(self, zeebe_worker, task):
+        job = random_job(task=task)
+
+        with patch("pyzeebe.worker.worker.ZeebeWorker._get_jobs") as get_jobs_mock:
+            get_jobs_mock.return_value = [job]
+            task.handler = MagicMock(return_value={"x": str(uuid4())})
+            zeebe_worker._handle_jobs(task)
+            task.handler.assert_called_with(job)
+
+
+class TestStartAndStop:
+
+    def test_work_thread_start_called(self, zeebe_worker, task):
+        with patch("pyzeebe.worker.worker.Thread") as thread_mock:
+            thread_instance_mock = MagicMock()
+            thread_mock.return_value = thread_instance_mock
+            zeebe_worker._add_task(task)
+            zeebe_worker.work()
+            zeebe_worker.stop()
+            thread_instance_mock.start.assert_called_once()
+
+    def test_stop_worker(self, zeebe_worker):
         zeebe_worker.work()
         zeebe_worker.stop()
-        thread_instance_mock.start.assert_called_once()
 
 
-def test_stop_worker(zeebe_worker):
-    zeebe_worker.work()
-    zeebe_worker.stop()
+class TestGetJobs:
+    def test_get_jobs(self, zeebe_worker, task):
+        zeebe_worker.zeebe_adapter.activate_jobs = MagicMock()
+        zeebe_worker._get_jobs(task)
+        zeebe_worker.zeebe_adapter.activate_jobs.assert_called_with(task_type=task.type, worker=zeebe_worker.name,
+                                                                    timeout=task.timeout,
+                                                                    max_jobs_to_activate=task.max_jobs_to_activate,
+                                                                    variables_to_fetch=task.variables_to_fetch,
+                                                                    request_timeout=zeebe_worker.request_timeout)
 
 
-def test_include_router_adds_task(zeebe_worker, router, task_type):
-    @router.task(task_type)
-    def task_fn(x):
-        return {"x": x}
+class TestIncludeRouter:
+    def test_include_router_adds_task(self, zeebe_worker, router, task_type):
+        self.include_router_with_task(zeebe_worker, router, task_type)
+        assert zeebe_worker.get_task(task_type) is not None
 
-    zeebe_worker.include_router(router)
-    assert zeebe_worker.get_task(task_type) is not None
+    def test_include_multiple_routers(self, zeebe_worker, routers):
+        for router in routers:
+            self.include_router_with_task(zeebe_worker, router)
 
+        assert len(zeebe_worker.tasks) == len(routers)
 
-def test_include_multiple_routers(zeebe_worker, routers):
-    for router in routers:
-        @router.task(str(uuid4()))
-        def task_fn(x):
-            return {"x": x}
+    def test_router_before_decorator(self, zeebe_worker, router, decorator, job_without_adapter):
+        router.before(decorator)
+        task = self.include_router_with_task(zeebe_worker, router)
+
+        task.handler(job_without_adapter)
+
+        assert decorator.call_count == 1
+
+    def test_router_after_decorator(self, zeebe_worker, router, decorator, job_without_adapter):
+        router.after(decorator)
+        task = self.include_router_with_task(zeebe_worker, router)
+
+        task.handler(job_without_adapter)
+
+        assert decorator.call_count == 1
+
+    @staticmethod
+    def include_router_with_task(zeebe_worker, router, task_type=None):
+        task_type = task_type or str(uuid4())
+
+        @router.task(task_type)
+        def _(x):
+            return dict(x=x)
 
         zeebe_worker.include_router(router)
-
-    assert len(zeebe_worker.tasks) == len(routers)
-
-
-def test_router_before_decorator(zeebe_worker, router, decorator, job_without_adapter, task_type):
-    router.before(decorator)
-
-    @router.task(task_type)
-    def task_fn(x):
-        return {"x": x}
-
-    zeebe_worker.include_router(router)
-    task = zeebe_worker.get_task(task_type)
-
-    task.handler(job_without_adapter)
-
-    assert decorator.call_count == 1
-
-
-def test_router_after_decorator(zeebe_worker, router, decorator, job_without_adapter, task_type):
-    router.after(decorator)
-
-    @router.task(task_type)
-    def task_fn(x):
-        return {"x": x}
-
-    zeebe_worker.include_router(router)
-    task = zeebe_worker.get_task(task_type)
-
-    task.handler(job_without_adapter)
-
-    assert decorator.call_count == 1
-
-
-def test_router_non_dict_task(zeebe_worker, task_type):
-    with patch("pyzeebe.worker.task_handler.ZeebeTaskHandler._single_value_function_to_dict") as single_value_mock:
-        variable_name = str(uuid4())
-
-        @zeebe_worker.task(task_type=task_type, single_value=True, variable_name=variable_name)
-        def task_fn(x):
-            return {"x": x}
-
-        single_value_mock.assert_called_with(variable_name=variable_name, fn=task_fn)
-    assert len(zeebe_worker.tasks) == 1
-
-
-def test_get_jobs(zeebe_worker, task):
-    zeebe_worker.zeebe_adapter.activate_jobs = MagicMock()
-    zeebe_worker._get_jobs(task)
-    zeebe_worker.zeebe_adapter.activate_jobs.assert_called_with(task_type=task.type, worker=zeebe_worker.name,
-                                                                timeout=task.timeout,
-                                                                max_jobs_to_activate=task.max_jobs_to_activate,
-                                                                variables_to_fetch=task.variables_to_fetch,
-                                                                request_timeout=zeebe_worker.request_timeout)
+        return zeebe_worker.get_task(task_type)
 
 
 def test_watch_task_threads_dont_restart_running_threads(
@@ -302,6 +265,7 @@ def test_watch_task_threads_dont_restart_running_threads(
     zeebe_worker._watch_task_threads(frequency=0)
 
     assert handle_not_alive_thread_spy.call_count == 0
+
 
 def test_watch_task_threads_that_die_get_restarted_then_exit_after_too_many_errors(
         zeebe_worker, task, handle_task_mock, stop_event_mock, handle_not_alive_thread_spy):


### PR DESCRIPTION
This pr aims to clean up the worker tests, as I felt they were getting messy and unmaintainable.
I also plan to refactor the worker class itself in the near future, which will require the tests to be clean.

## Changes

- Order worker tests into classes. This should make it easier to find and read tests.

## Checklist

- [x] Unit tests
- [x] Documentation
