### PR TITLE
Change watcher to check for consecutive errors per thread

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = '2020, Jonatan Martens'
 author = 'Jonatan Martens'
 
 # The full version, including alpha/beta/rc tags
-release = '2.3.0'
+release = '2.3.1'
 
 # -- General configuration ---------------------------------------------------
 
@@ -59,6 +59,6 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-version = "2.3.0"
+version = "2.3.1"
 
 master_doc = 'index'

--- a/pyzeebe/__init__.py
+++ b/pyzeebe/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 from pyzeebe import exceptions
 from pyzeebe.client.client import ZeebeClient

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -126,9 +126,9 @@ class ZeebeWorker(ZeebeTaskHandler):
             logger.debug("Checking task thread status")
             # converting to list to avoid "RuntimeError: dictionary changed size during iteration"
             for task_type in list(self._task_threads.keys()):
+                consecutive_errors.setdefault(task_type, 0)
                 # thread might be none, if dict changed size, in that case we'll consider it
                 # an error, and check if we should handle it
-                consecutive_errors.setdefault(task_type, 0)
                 thread = self._task_threads.get(task_type)
                 if not thread or not thread.is_alive():
                     consecutive_errors[task_type] += 1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyzeebe",
-    version="2.3.0",
+    version="2.3.1",
     author="Jonatan Martens",
     author_email="jonatanmartenstav@gmail.com",
     description="Zeebe client api",


### PR DESCRIPTION
Instead of checking if the total number of errors are greater, it will check for each thread.

## Changes

_See above/title_

## API Updates

### New Features *(required)*

None

### Deprecations *(required)*

None

### Enhancements *(optional)*

None

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #138 