### PR TITLE
Return workflow instance key alongside output variables for run_workflow_with_result

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ zeebe_client = ZeebeClient(hostname="localhost", port=26500)
 workflow_instance_key = zeebe_client.run_workflow(bpmn_process_id="My zeebe workflow", variables={})
 
 # Run a workflow and receive the result
-workflow_instance_key, workflow_with_result = zeebe_client.run_workflow_with_result(
+workflow_instance_key, workflow_result = zeebe_client.run_workflow_with_result(
     bpmn_process_id="My zeebe workflow",
     timeout=10000
 )

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyzeebe)
 ![PyPI](https://img.shields.io/pypi/v/pyzeebe)
 
-
-
 # Pyzeebe
+
 pyzeebe is a python grpc client for Zeebe.
 
 Zeebe version support:
 
-| Pyzeebe version | Tested Zeebe versions |
-|:---------------:|----------------|
-| 2.x.x           | 0.23, 0.24, 0.25, 0.26        |
-| 1.x.x           | 0.23, 0.24         |
+| Pyzeebe version | Tested Zeebe versions  |
+| :-------------: | ---------------------- |
+|      2.x.x      | 0.23, 0.24, 0.25, 0.26 |
+|      1.x.x      | 0.23, 0.24             |
 
 ## Getting Started
+
 To install:
 
 `pip install pyzeebe`
@@ -40,7 +40,7 @@ from pyzeebe import ZeebeWorker, Job
 def on_error(exception: Exception, job: Job):
     """
     on_error will be called when the task fails
-    """ 
+    """
     print(exception)
     job.set_error_status(f"Failed to handle job {job}. Error: {str(exception)}")
 
@@ -57,9 +57,10 @@ worker.work() # Now every time that a task with type example is called example_t
 ```
 
 Stop a worker:
+
 ```python
 zeebe_worker.work() # Worker will begin working
-zeebe_worker.stop() # Stops worker after all running jobs have been completed 
+zeebe_worker.stop() # Stops worker after all running jobs have been completed
 ```
 
 ### Client
@@ -74,8 +75,10 @@ zeebe_client = ZeebeClient(hostname="localhost", port=26500)
 workflow_instance_key = zeebe_client.run_workflow(bpmn_process_id="My zeebe workflow", variables={})
 
 # Run a workflow and receive the result
-workflow_result = zeebe_client.run_workflow_with_result(bpmn_process_id="My zeebe workflow",
-                                                        timeout=10000)  # Will wait 10000 milliseconds (10 seconds)
+workflow_instance_key, workflow_with_result = zeebe_client.run_workflow_with_result(
+    bpmn_process_id="My zeebe workflow",
+    timeout=10000
+)
 
 # Deploy a bpmn workflow definition
 zeebe_client.deploy_workflow("workflow.bpmn")
@@ -89,18 +92,21 @@ zeebe_client.publish_message(name="message_name", correlation_key="some_id")
 ```
 
 ## Tests
+
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install pyzeebe
- 
+
 `pytest tests/unit`
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
-
 ## Versioning
+
 We use [SemVer](semver.org) for versioning. For the versions available, see the tags on this repository.
 
 ## License
+
 We use the MIT license, see [LICENSE.md](LICENSE.md) for details

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -78,7 +78,7 @@ To run a workflow and receive the result directly:
 
 .. code-block:: python
 
-    result = client.run_workflow_with_result("bpmn_process_id")
+    workflow_instance_key, result = client.run_workflow_with_result("bpmn_process_id")
 
     # result will be a dict
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -15,8 +15,10 @@ zeebe_client = ZeebeClient(credentials=camunda_cloud_credentials)
 workflow_instance_key = zeebe_client.run_workflow(bpmn_process_id="My zeebe workflow", variables={})
 
 # Run a workflow and receive the result
-workflow_result = zeebe_client.run_workflow_with_result(bpmn_process_id="My zeebe workflow",
-                                                        timeout=10000)  # Will wait 10000 milliseconds (10 seconds)
+workflow_instance_key, workflow_result = zeebe_client.run_workflow_with_result(
+    bpmn_process_id="My zeebe workflow",
+    timeout=10000
+)  # Will wait 10000 milliseconds (10 seconds)
 
 # Deploy a bpmn workflow definition
 zeebe_client.deploy_workflow("workflow.bpmn")

--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import grpc
 
@@ -47,7 +47,7 @@ class ZeebeClient(object):
                                                            version=version)
 
     def run_workflow_with_result(self, bpmn_process_id: str, variables: Dict = None, version: int = -1,
-                                 timeout: int = 0, variables_to_fetch: List[str] = None) -> Dict:
+                                 timeout: int = 0, variables_to_fetch: List[str] = None) -> Tuple[int, Dict]:
         """
         Run workflow and wait for the result.
 
@@ -59,7 +59,7 @@ class ZeebeClient(object):
             variables_to_fetch (List[str]): Which variables to get from the finished workflow
 
         Returns:
-            dict: A dictionary of the end state of the workflow instance
+            tuple: (The workflow instance key, A dictionary of the end state of the workflow instance)
 
         Raises:
             WorkflowNotFound: No workflow with bpmn_process_id exists

--- a/pyzeebe/grpc_internals/zeebe_workflow_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_workflow_adapter.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict
+from typing import Dict, Tuple
 
 import grpc
 from zeebe_grpc.gateway_pb2 import CreateWorkflowInstanceRequest, CreateWorkflowInstanceWithResultRequest, \
@@ -22,14 +22,14 @@ class ZeebeWorkflowAdapter(ZeebeAdapterBase):
             self._create_workflow_errors(rpc_error, bpmn_process_id, version, variables)
 
     def create_workflow_instance_with_result(self, bpmn_process_id: str, version: int, variables: Dict,
-                                             timeout: int, variables_to_fetch) -> Dict:
+                                             timeout: int, variables_to_fetch) -> Tuple[int, Dict]:
         try:
             response = self._gateway_stub.CreateWorkflowInstanceWithResult(
                 CreateWorkflowInstanceWithResultRequest(
                     request=CreateWorkflowInstanceRequest(bpmnProcessId=bpmn_process_id, version=version,
                                                           variables=json.dumps(variables)),
                     requestTimeout=timeout, fetchVariables=variables_to_fetch))
-            return json.loads(response.variables)
+            return response.workflowInstanceKey, json.loads(response.variables)
         except grpc.RpcError as rpc_error:
             self._create_workflow_errors(rpc_error, bpmn_process_id, version, variables)
 

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -32,7 +32,9 @@ def setup():
     zeebe_client = ZeebeClient()
     try:
         integration_tests_path = os.path.join("tests", "integration")
-        zeebe_client.deploy_workflow(os.path.join(integration_tests_path, "test.bpmn"))
+        zeebe_client.deploy_workflow(
+            os.path.join(integration_tests_path, "test.bpmn")
+        )
     except FileNotFoundError:
         zeebe_client.deploy_workflow("test.bpmn")
 
@@ -42,7 +44,10 @@ def setup():
 
 
 def test_run_workflow():
-    workflow_key = zeebe_client.run_workflow("test", {"input": str(uuid4()), "should_throw": False})
+    workflow_key = zeebe_client.run_workflow(
+        "test",
+        {"input": str(uuid4()), "should_throw": False}
+    )
     assert isinstance(workflow_key, int)
 
 
@@ -53,11 +58,18 @@ def test_non_existent_workflow():
 
 def test_run_workflow_with_result():
     input = str(uuid4())
-    output = zeebe_client.run_workflow_with_result("test", {"input": input, "should_throw": False})
-    assert isinstance(output["output"], str)
-    assert output["output"].startswith(input)
+    workflow_instance_key, workflow_result = zeebe_client.run_workflow_with_result(
+        "test",
+        {"input": input, "should_throw": False}
+    )
+    assert isinstance(workflow_instance_key, int)
+    assert isinstance(workflow_result["output"], str)
+    assert workflow_result["output"].startswith(input)
 
 
 def test_cancel_workflow():
-    workflow_key = zeebe_client.run_workflow("test", {"input": str(uuid4()), "should_throw": False})
+    workflow_key = zeebe_client.run_workflow(
+        "test",
+        {"input": str(uuid4()), "should_throw": False}
+    )
     zeebe_client.cancel_workflow_instance(workflow_key)

--- a/tests/unit/client/client_test.py
+++ b/tests/unit/client/client_test.py
@@ -14,11 +14,28 @@ def test_run_workflow(zeebe_client, grpc_servicer):
     assert isinstance(zeebe_client.run_workflow(bpmn_process_id=bpmn_process_id, variables={}, version=version), int)
 
 
-def test_run_workflow_with_result(zeebe_client, grpc_servicer):
-    bpmn_process_id = str(uuid4())
-    version = randint(0, 10)
-    grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    assert isinstance(zeebe_client.run_workflow(bpmn_process_id=bpmn_process_id, variables={}, version=version), int)
+class TestRunWorkflowWithResult:
+    @pytest.fixture
+    def deployed_workflow(self, grpc_servicer):
+        bpmn_process_id = str(uuid4())
+        version = randint(0, 10)
+        grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
+        return bpmn_process_id, version
+
+    def test_run_workflow_with_result_instance_key_is_int(self, zeebe_client, deployed_workflow):
+        bpmn_process_id, version = deployed_workflow
+
+        workflow_instance_key, _ = zeebe_client.run_workflow_with_result(bpmn_process_id, {}, version)
+
+        assert isinstance(workflow_instance_key, int)
+
+    def test_run_workflow_with_result_output_variables_are_as_expected(self, zeebe_client, deployed_workflow):
+        expected = {}
+        bpmn_process_id, version = deployed_workflow
+
+        _, output_variables = zeebe_client.run_workflow_with_result(bpmn_process_id, {}, version)
+
+        assert output_variables == expected
 
 
 def test_deploy_workflow(zeebe_client):

--- a/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
@@ -38,10 +38,10 @@ def test_create_workflow_instance_with_result(grpc_servicer, zeebe_adapter):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    response = zeebe_adapter.create_workflow_instance_with_result(bpmn_process_id=bpmn_process_id,
-                                                                  variables={},
-                                                                  version=version, timeout=0,
-                                                                  variables_to_fetch=[])
+    _, response = zeebe_adapter.create_workflow_instance_with_result(bpmn_process_id=bpmn_process_id,
+                                                                     variables={},
+                                                                     version=version, timeout=0,
+                                                                     variables_to_fetch=[])
     assert isinstance(response, dict)
 
 

--- a/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_workflow_adapter_test.py
@@ -34,14 +34,18 @@ def test_create_workflow_instance_common_errors_called(zeebe_adapter):
     zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 
 
-def test_create_workflow_instance_with_result(grpc_servicer, zeebe_adapter):
+def test_create_workflow_instance_with_result_return_types(grpc_servicer, zeebe_adapter):
     bpmn_process_id = str(uuid4())
     version = randint(0, 10)
     grpc_servicer.mock_deploy_workflow(bpmn_process_id, version, [])
-    _, response = zeebe_adapter.create_workflow_instance_with_result(bpmn_process_id=bpmn_process_id,
-                                                                     variables={},
-                                                                     version=version, timeout=0,
-                                                                     variables_to_fetch=[])
+    workflow_instance_key, response = zeebe_adapter.create_workflow_instance_with_result(
+        bpmn_process_id=bpmn_process_id,
+        variables={},
+        version=version,
+        timeout=0,
+        variables_to_fetch=[]
+    )
+    assert isinstance(workflow_instance_key, int)
     assert isinstance(response, dict)
 
 


### PR DESCRIPTION
Return the workflow instance key when waiting for a workflow result.

## Changes

- `ZeebeClient.run_workflow_with_result` will now return a tuple of the (workflow_instance_key, output variables)

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Implements #105 
